### PR TITLE
Update composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,16 +14,16 @@
     "authors": [
         {
             "name": "Graze tech team",
-            "homepage": "https://github.com/graze/prof/graphs/contributors"
+            "homepage": "https://github.com/graze/morphism/graphs/contributors"
         }
     ],
     "require": {
         "php": ">=5.4",
-        "symfony/yaml": "~2.4.2",
-        "doctrine/dbal": "~2.4.2"
+        "symfony/yaml": "~2.6",
+        "doctrine/dbal": "~2.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0.11"
+        "phpunit/phpunit": "~4.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Wasn't able to install this in graze/web because of the outdated dependencies, this updates them to their latest stable versions.

All tests pass on dev.
