### PR TITLE
Code coverage

### DIFF
--- a/src/Parse/CollationInfo.php
+++ b/src/Parse/CollationInfo.php
@@ -80,7 +80,7 @@ class CollationInfo
     public function getCharset()
     {
         if (is_null($this->_charset)) {
-            throw new \LogicException("getCharset called when collation is unspecified");
+            throw new \LogicException("getCharset called when charset is unspecified");
         }
         return $this->_charset;
     }
@@ -198,6 +198,8 @@ class CollationInfo
     }
 
     /**
+     * Get all the available collations for the given character set.
+     *
      * @param string $charset
      * @return string|null
      */
@@ -209,6 +211,8 @@ class CollationInfo
     }
 
     /**
+     * Get the default collation for the given character set.
+     *
      * @param string $charset
      * @return string|null
      */
@@ -222,6 +226,8 @@ class CollationInfo
     }
 
     /**
+     * Get the binary collation for the given character set.
+     *
      * @param string $charset
      * @return string|null
      */

--- a/tests/Parse/CollationInfoTest.php
+++ b/tests/Parse/CollationInfoTest.php
@@ -47,7 +47,30 @@ class CollationInfoTest extends \Graze\Morphism\Test\Parse\TestCase
             ['binary', null,                'binary', 'binary'],
             ['binary', 'binary',            'binary', 'binary'],
             [null,     'binary',            'binary', 'binary'],
+        ];
+    }
 
+    /**
+     * @param string $charset
+     * @param string $collation
+     * @dataProvider providerConstructorWithBadArgs
+     * @expectedException \RuntimeException
+     */
+    public function testConstructorWithBadArgs($charset, $collation)
+    {
+        $collation = new CollationInfo($charset, $collation);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerConstructorWithBadArgs()
+    {
+        return [
+            // Invalid character set
+            ['foo', 'utf8_general_ci'],
+            // Invalid collation
+            ['utf8', 'foo'],
         ];
     }
 
@@ -78,6 +101,12 @@ class CollationInfoTest extends \Graze\Morphism\Test\Parse\TestCase
         $this->assertFalse((new CollationInfo('utf8', 'utf8_bin'))->isBinaryCharset());
     }
 
+    /** @expectedException \LogicException */
+    public function testInvalidIsBinaryCharset()
+    {
+        (new CollationInfo())->isBinaryCharset();
+    }
+
     public function testIsDefaultCollation()
     {
         $this->assertTrue((new CollationInfo('utf8'))->isDefaultCollation());
@@ -87,6 +116,12 @@ class CollationInfoTest extends \Graze\Morphism\Test\Parse\TestCase
 
         $this->assertFalse((new CollationInfo('utf8', 'utf8_unicode_ci'))->isDefaultCollation());
         $this->assertFalse((new CollationInfo('latin1', 'latin1_general_ci'))->isDefaultCollation());
+    }
+
+    /** @expectedException \LogicException */
+    public function testInvalidSiDefaulfCollation()
+    {
+        (new CollationInfo())->isDefaultCollation();
     }
 
     public function testSetCharset()
@@ -106,6 +141,12 @@ class CollationInfoTest extends \Graze\Morphism\Test\Parse\TestCase
         (new CollationInfo('latin1'))->setCharset('utf8');
     }
 
+    /** @expectedException \LogicException */
+    public function testEmptyCharsetFail()
+    {
+        (new CollationInfo())->getCharset();
+    }
+
     public function testSetCollation()
     {
         $collation = new CollationInfo();
@@ -123,5 +164,20 @@ class CollationInfoTest extends \Graze\Morphism\Test\Parse\TestCase
     public function testSetCollationFail()
     {
         (new CollationInfo('latin1'))->setCollation('utf8_general_ci');
+    }
+
+    public function testGetCollation()
+    {
+        $collation = new CollationInfo(null, 'utf8_unicode_ci');
+        $this->assertSame('utf8_unicode_ci', $collation->getCollation());
+
+        $collation->setBinaryCollation();
+        $this->assertSame('utf8_bin', $collation->getCollation());
+    }
+
+    /** @expectedException \LogicException */
+    public function testEmptyCollationFail()
+    {
+        (new CollationInfo())->getCollation();
     }
 }


### PR DESCRIPTION
Increasing the code coverage.

- Improvements to exception messages.
- Lots of new tests for the two classes with the lowest test coverage:
  - `Graze\Morphism\Parse\CollationInfo`
  - `Graze\Morphism\Parse\ColumnInfo`.

The results of `make test-coverage` before:
![image](https://user-images.githubusercontent.com/1482649/28845506-3053387a-7700-11e7-8046-c4ced0d97036.png)

The results afterwards:
![image](https://user-images.githubusercontent.com/1482649/28845537-4819b7ea-7700-11e7-9c66-9e245e8227af.png)

Progress!

Here's the coverage according to scrutinizer. I'll give the updated value when this is merged.
![image](https://user-images.githubusercontent.com/1482649/28845596-7ce3a94a-7700-11e7-83cb-e64f895ba08b.png)

