### PR TITLE
Token type constants

### DIFF
--- a/src/Parse/ColumnDefinition.php
+++ b/src/Parse/ColumnDefinition.php
@@ -189,7 +189,7 @@ class ColumnDefinition
     private function _parseColumnDatatype(TokenStream $stream)
     {
         $token = $stream->nextToken();
-        if ($token->type !== 'identifier') {
+        if ($token->type !== Token::IDENTIFIER) {
             throw new \RuntimeException("expected a datatype");
         }
 
@@ -261,10 +261,10 @@ class ColumnDefinition
                 while (true) {
                     $this->elements[] = rtrim($stream->expectStringExtended(), " ");
                     $token = $stream->nextToken();
-                    if ($token->eq('symbol', ',')) {
+                    if ($token->eq(Token::SYMBOL, ',')) {
                         continue;
                     }
-                    if ($token->eq('symbol', ')')) {
+                    if ($token->eq(Token::SYMBOL, ')')) {
                         break;
                     }
                     throw new \RuntimeException("expected ',' or ')'");
@@ -280,12 +280,12 @@ class ColumnDefinition
 
             default:
                 $spec = $typeInfo->formatSpec;
-                if ($stream->consume([['symbol', '(']])) {
+                if ($stream->consume([[Token::SYMBOL, '(']])) {
                     if (!($spec[1] || $spec[2])) {
                         throw new \RuntimeException("unexpected '('");
                     }
                     $format[] = $stream->expectNumber();
-                    if ($stream->consume([['symbol', ',']])) {
+                    if ($stream->consume([[Token::SYMBOL, ',']])) {
                         if (!$spec[2]) {
                             throw new \RuntimeException("unexpected ','");
                         }
@@ -306,22 +306,22 @@ class ColumnDefinition
         while (true) {
             $mark = $stream->getMark();
             $token1 = $stream->nextToken();
-            if ($token1->type !== 'identifier') {
+            if ($token1->type !== Token::IDENTIFIER) {
                 $stream->rewind($mark);
                 break;
             }
 
-            if ($token1->eq('identifier', 'ZEROFILL')) {
+            if ($token1->eq(Token::IDENTIFIER, 'ZEROFILL')) {
                 if (!$typeInfo->allowZerofill) {
                     throw new \RuntimeException("unexpected ZEROFILL");
                 }
                 $this->zerofill = true;
-            } elseif ($token1->eq('identifier', 'UNSIGNED')) {
+            } elseif ($token1->eq(Token::IDENTIFIER, 'UNSIGNED')) {
                 if (!$typeInfo->allowSign) {
                     throw new \RuntimeException("unexpected UNSIGNED");
                 }
                 $this->unsigned = true;
-            } elseif ($token1->eq('identifier', 'SIGNED')) {
+            } elseif ($token1->eq(Token::IDENTIFIER, 'SIGNED')) {
                 if (!$typeInfo->allowSign) {
                     throw new \RuntimeException("unexpected SIGNED");
                 }
@@ -361,18 +361,18 @@ class ColumnDefinition
         while (true) {
             $mark = $stream->getMark();
             $token1 = $stream->nextToken();
-            if ($token1->type !== 'identifier') {
+            if ($token1->type !== Token::IDENTIFIER) {
                 $stream->rewind($mark);
                 break;
             }
 
-            if ($token1->eq('identifier', 'BINARY')) {
+            if ($token1->eq(Token::IDENTIFIER, 'BINARY')) {
                 if (!$typeInfo->allowBinary) {
                     throw new \RuntimeException("unexpected BINARY");
                 }
                 $this->collation->setBinaryCollation();
-            } elseif ($token1->eq('identifier', 'CHARSET') ||
-                $token1->eq('identifier', 'CHARACTER') && $stream->consume('SET')
+            } elseif ($token1->eq(Token::IDENTIFIER, 'CHARSET') ||
+                $token1->eq(Token::IDENTIFIER, 'CHARACTER') && $stream->consume('SET')
             ) {
                 if (!$typeInfo->allowCharset) {
                     throw new \RuntimeException("unexpected CHARSET");
@@ -402,35 +402,35 @@ class ColumnDefinition
         while (true) {
             $mark = $stream->getMark();
             $token1 = $stream->nextToken();
-            if ($token1->type !== 'identifier') {
+            if ($token1->type !== Token::IDENTIFIER) {
                 $stream->rewind($mark);
                 break;
             }
 
-            if ($token1->eq('identifier', 'NOT') &&
+            if ($token1->eq(Token::IDENTIFIER, 'NOT') &&
                 $stream->consume('NULL')
             ) {
                 $this->nullable = false;
-            } elseif ($token1->eq('identifier', 'NULL')
+            } elseif ($token1->eq(Token::IDENTIFIER, 'NULL')
             ) {
                 if (!$this->autoIncrement) {
                     $this->nullable = true;
                 }
-            } elseif ($token1->eq('identifier', 'DEFAULT')
+            } elseif ($token1->eq(Token::IDENTIFIER, 'DEFAULT')
             ) {
                 $token2 = $stream->nextToken();
 
-                if ($token2->eq('identifier', 'NOW') ||
-                    $token2->eq('identifier', 'CURRENT_TIMESTAMP') ||
-                    $token2->eq('identifier', 'LOCALTIME') ||
-                    $token2->eq('identifier', 'LOCALTIMESTAMP')
+                if ($token2->eq(Token::IDENTIFIER, 'NOW') ||
+                    $token2->eq(Token::IDENTIFIER, 'CURRENT_TIMESTAMP') ||
+                    $token2->eq(Token::IDENTIFIER, 'LOCALTIME') ||
+                    $token2->eq(Token::IDENTIFIER, 'LOCALTIMESTAMP')
                 ) {
-                    if (!$stream->consume([['symbol', '('], ['symbol', ')']]) &&
-                        $token2->eq('identifier', 'NOW')
+                    if (!$stream->consume([[Token::SYMBOL, '('], [Token::SYMBOL, ')']]) &&
+                        $token2->eq(Token::IDENTIFIER, 'NOW')
                     ) {
                         throw new \RuntimeException("expected () after keyword NOW");
                     }
-                    $token2 = new Token('identifier', 'CURRENT_TIMESTAMP');
+                    $token2 = new Token(Token::IDENTIFIER, 'CURRENT_TIMESTAMP');
                 }
 
                 try {
@@ -438,17 +438,17 @@ class ColumnDefinition
                 } catch (Exception $e) {
                     throw new \RuntimeException("invalid DEFAULT for '" . $this->name . "'");
                 }
-            } elseif ($token1->eq('identifier', 'ON') &&
+            } elseif ($token1->eq(Token::IDENTIFIER, 'ON') &&
                 $stream->consume('UPDATE')
             ) {
                 $token2 = $stream->nextToken();
-                if ($token2->eq('identifier', 'NOW') ||
-                    $token2->eq('identifier', 'CURRENT_TIMESTAMP') ||
-                    $token2->eq('identifier', 'LOCALTIME') ||
-                    $token2->eq('identifier', 'LOCALTIMESTAMP')
+                if ($token2->eq(Token::IDENTIFIER, 'NOW') ||
+                    $token2->eq(Token::IDENTIFIER, 'CURRENT_TIMESTAMP') ||
+                    $token2->eq(Token::IDENTIFIER, 'LOCALTIME') ||
+                    $token2->eq(Token::IDENTIFIER, 'LOCALTIMESTAMP')
                 ) {
-                    if (!$stream->consume([['symbol', '('], ['symbol', ')']]) &&
-                        $token2->eq('identifier', 'NOW')
+                    if (!$stream->consume([[Token::SYMBOL, '('], [Token::SYMBOL, ')']]) &&
+                        $token2->eq(Token::IDENTIFIER, 'NOW')
                     ) {
                         throw new \RuntimeException("expected () after keyword NOW");
                     }
@@ -459,26 +459,26 @@ class ColumnDefinition
                 } else {
                     throw new \RuntimeException("expected CURRENT_TIMESTAMP, NOW, LOCALTIME or LOCALTIMESTAMP");
                 }
-            } elseif ($token1->eq('identifier', 'AUTO_INCREMENT')
+            } elseif ($token1->eq(Token::IDENTIFIER, 'AUTO_INCREMENT')
             ) {
                 if (!$this->_getTypeInfo()->allowAutoIncrement) {
                     throw new \RuntimeException("AUTO_INCREMENT not allowed for this datatype");
                 }
                 $this->autoIncrement = true;
                 $this->nullable = false;
-            } elseif ($token1->eq('identifier', 'UNIQUE')
+            } elseif ($token1->eq(Token::IDENTIFIER, 'UNIQUE')
             ) {
                 $stream->consume('KEY');
                 $this->_uniqueKey = true;
-            } elseif ($token1->eq('identifier', 'PRIMARY') && $stream->consume('KEY') ||
-                $token1->eq('identifier', 'KEY')
+            } elseif ($token1->eq(Token::IDENTIFIER, 'PRIMARY') && $stream->consume('KEY') ||
+                $token1->eq(Token::IDENTIFIER, 'KEY')
             ) {
                 $this->_primaryKey = true;
                 $this->nullable = false;
-            } elseif ($token1->eq('identifier', 'COMMENT')
+            } elseif ($token1->eq(Token::IDENTIFIER, 'COMMENT')
             ) {
                 $this->comment = $stream->expectString();
-            } elseif ($token1->eq('identifier', 'SERIAL') &&
+            } elseif ($token1->eq(Token::IDENTIFIER, 'SERIAL') &&
                 $stream->consume('DEFAULT VALUE')
             ) {
                 if (!$this->_getTypeInfo()->allowAutoIncrement) {
@@ -540,21 +540,21 @@ class ColumnDefinition
      */
     private function _defaultValue(Token $token)
     {
-        if ($token->eq('identifier', 'NULL')) {
+        if ($token->eq(Token::IDENTIFIER, 'NULL')) {
             if (!$this->nullable) {
                 throw new \Exception("Column type cannot have NULL default: $this->type");
             }
             return null;
         }
 
-        if ($token->eq('identifier', 'CURRENT_TIMESTAMP')) {
+        if ($token->eq(Token::IDENTIFIER, 'CURRENT_TIMESTAMP')) {
             if (!in_array($this->type, ['timestamp', 'datetime'])) {
                 throw new \Exception("Only 'timestamp' and 'datetime' types can have default value of CURRENT_TIMESTAMP");
             }
             return 'CURRENT_TIMESTAMP';
         }
 
-        if (!in_array($token->type, ['string', 'hex', 'bin', 'number'])) {
+        if (!in_array($token->type, [Token::STRING, Token::HEX, Token::BIN, Token::NUMBER])) {
             throw new \Exception("Invalid token type for default value: $token->type");
         }
 
@@ -600,7 +600,7 @@ class ColumnDefinition
 
             case 'year':
                 $year = $token->asNumber();
-                if ($token->type !== 'string' && $year == 0) {
+                if ($token->type !== Token::STRING && $year == 0) {
                     return '0000';
                 }
                 if ($year < 70) {
@@ -624,7 +624,7 @@ class ColumnDefinition
                 return str_pad($token->asString(), $this->length, "\0");
 
             case 'enum':
-                if ($token->type !== 'string') {
+                if ($token->type !== Token::STRING) {
                     throw new \Exception("Invalid data type for default enum value: $token->type");
                 }
                 foreach ($this->elements as $element) {
@@ -635,7 +635,7 @@ class ColumnDefinition
                 throw new \Exception("Default enum value not found in enum: $token->text");
 
             case 'set':
-                if ($token->type !== 'string') {
+                if ($token->type !== Token::STRING) {
                     throw new \Exception("Invalid type for default set value: $token->type");
                 }
                 if ($token->text === '') {

--- a/src/Parse/CreateDatabase.php
+++ b/src/Parse/CreateDatabase.php
@@ -56,7 +56,7 @@ class CreateDatabase
             if ($stream->consume('CHARSET') ||
                 $stream->consume('CHARACTER SET')
             ) {
-                $stream->consume([['symbol', '=']]);
+                $stream->consume([[Token::SYMBOL, '=']]);
                 $charset = $stream->expectName();
                 if (strtoupper($charset) === 'DEFAULT') {
                     $this->_collation = new CollationInfo();
@@ -64,7 +64,7 @@ class CreateDatabase
                     $this->_collation->setCharset($charset);
                 }
             } elseif ($stream->consume('COLLATE')) {
-                $stream->consume([['symbol', '=']]);
+                $stream->consume([[Token::SYMBOL, '=']]);
                 $collation = $stream->expectName();
                 if (strtoupper($collation) === 'DEFAULT') {
                     $this->_collation = new CollationInfo();

--- a/src/Parse/CreateTable.php
+++ b/src/Parse/CreateTable.php
@@ -107,9 +107,9 @@ class CreateTable
                 $this->_parseColumn($stream);
             }
             $token = $stream->nextToken();
-            if ($token->eq('symbol', ',')) {
+            if ($token->eq(Token::SYMBOL, ',')) {
                 continue;
-            } elseif ($token->eq('symbol', ')')) {
+            } elseif ($token->eq(Token::SYMBOL, ')')) {
                 break;
             } else {
                 throw new RuntimeException("Expected ',' or ')'");

--- a/src/Parse/IndexDefinition.php
+++ b/src/Parse/IndexDefinition.php
@@ -104,7 +104,7 @@ class IndexDefinition
     {
         $mark = $stream->getMark();
         $token = $stream->nextToken();
-        if ($token->type === 'identifier') {
+        if ($token->type === Token::IDENTIFIER) {
             $this->name = $token->text;
         } else {
             $stream->rewind($mark);
@@ -151,16 +151,16 @@ class IndexDefinition
     private function expectIndexColumns(TokenStream $stream)
     {
         $columns = [];
-        $stream->expect('symbol', '(');
+        $stream->expect(Token::SYMBOL, '(');
         while (true) {
             $column = [
                 'name'   => $stream->expectName(),
                 'length' => null,
                 'sort'   => 'ASC',
             ];
-            if ($stream->consume([['symbol', '(']])) {
+            if ($stream->consume([[Token::SYMBOL, '(']])) {
                 $column['length'] = $stream->expectNumber();
-                $stream->expect('symbol', ')');
+                $stream->expect(Token::SYMBOL, ')');
             }
             if ($stream->consume('ASC')) {
                 $column['sort'] = 'ASC';
@@ -168,12 +168,12 @@ class IndexDefinition
                 $column['sort'] = 'DESC';
             }
             $columns[] = $column;
-            if (!$stream->consume([['symbol', ',']])) {
+            if (!$stream->consume([[Token::SYMBOL, ',']])) {
                 break;
             }
         }
 
-        $stream->expect('symbol', ')');
+        $stream->expect(Token::SYMBOL, ')');
 
         return $columns;
     }
@@ -185,7 +185,7 @@ class IndexDefinition
     {
         while (true) {
             if ($stream->consume('KEY_BLOCK_SIZE')) {
-                $stream->consume([['symbol', '=']]);
+                $stream->consume([[Token::SYMBOL, '=']]);
                 $this->options['KEY_BLOCK_SIZE'] = $stream->expectNumber();
             } elseif ($stream->consume('WITH PARSER')) {
                 $this->options['WITH PARSER'] = $stream->expectName();
@@ -204,10 +204,10 @@ class IndexDefinition
      */
     private function parseReferenceDefinition(TokenStream $stream)
     {
-        $stream->expect('identifier', 'REFERENCES');
+        $stream->expect(Token::IDENTIFIER, 'REFERENCES');
 
         $tableOrSchema = $stream->expectName();
-        if ($stream->consume([['symbol', '.']])) {
+        if ($stream->consume([[Token::SYMBOL, '.']])) {
             $schema = $tableOrSchema;
             $table = $stream->expectName();
         } else {

--- a/src/Parse/MysqlDump.php
+++ b/src/Parse/MysqlDump.php
@@ -136,7 +136,7 @@ class MysqlDump
             if ($stream->peek('CREATE DATABASE')) {
                 $this->database = new CreateDatabase($this->_defaultCollation);
                 $this->database->parse($stream);
-                $stream->expect('symbol', ';');
+                $stream->expect(Token::SYMBOL, ';');
 
                 $this->databases[$this->database->name] = $this->database;
             } elseif ($stream->peek('CREATE TABLE')) {
@@ -149,7 +149,7 @@ class MysqlDump
                 $table = new CreateTable($this->database->getCollation());
                 $table->setDefaultEngine($this->_defaultEngine);
                 $table->parse($stream);
-                $stream->expect('symbol', ';');
+                $stream->expect(Token::SYMBOL, ';');
 
                 $includeTablesRegex = $flags['matchTables']['include'];
                 $excludeTablesRegex = $flags['matchTables']['exclude'];
@@ -175,7 +175,7 @@ class MysqlDump
             if ($token->isEof()) {
                 return false;
             }
-            if ($token->eq('symbol', ';')) {
+            if ($token->eq(Token::SYMBOL, ';')) {
                 return true;
             }
         }

--- a/src/Parse/TableOptions.php
+++ b/src/Parse/TableOptions.php
@@ -70,14 +70,14 @@ class TableOptions
         while (true) {
             $mark = $stream->getMark();
             $token = $stream->nextToken();
-            if ($token->type !== 'identifier') {
+            if ($token->type !== Token::IDENTIFIER) {
                 $stream->rewind($mark);
                 break;
             }
 
-            if ($token->eq('identifier', 'DEFAULT')) {
+            if ($token->eq(Token::IDENTIFIER, 'DEFAULT')) {
                 $token = $stream->nextToken();
-                if (!($token->type === 'identifier' &&
+                if (!($token->type === Token::IDENTIFIER &&
                       in_array(strtoupper($token->text), ['CHARSET', 'CHARACTER', 'COLLATE']))
                 ) {
                     throw new \RuntimeException("Expected CHARSET, CHARACTER SET or COLLATE");
@@ -106,7 +106,7 @@ class TableOptions
                 break;
 
             case 'CHARACTER':
-                $stream->expect('identifier', 'SET');
+                $stream->expect(Token::IDENTIFIER, 'SET');
                 $this->_parseIdentifier($stream, 'CHARSET');
                 break;
 
@@ -129,7 +129,7 @@ class TableOptions
 
             case 'DATA':
             case 'INDEX':
-                $stream->expect('identifier', 'DIRECTORY');
+                $stream->expect(Token::IDENTIFIER, 'DIRECTORY');
                 // fall through //
             case 'COMMENT':
             case 'CONNECTION':
@@ -214,12 +214,12 @@ class TableOptions
      */
     private function _parseIdentifier(TokenStream $stream, $option)
     {
-        $stream->consume([['symbol', '=']]);
+        $stream->consume([[Token::SYMBOL, '=']]);
         $token = $stream->nextToken();
         if ($token->isEof()) {
             throw new \RuntimeException("Unexpected end-of-file");
         }
-        if (!in_array($token->type, ['identifier', 'string'])) {
+        if (!in_array($token->type, [Token::IDENTIFIER, Token::STRING])) {
             throw new \RuntimeException("Bad table option value: '$token->text'");
         }
         $this->setOption($option, strtolower($token->text));
@@ -231,7 +231,7 @@ class TableOptions
      */
     private function _parseNumber(TokenStream $stream, $option)
     {
-        $stream->consume([['symbol', '=']]);
+        $stream->consume([[Token::SYMBOL, '=']]);
         $this->setOption($option, $stream->expectNumber());
     }
 
@@ -242,9 +242,9 @@ class TableOptions
      */
     private function _parseEnum(TokenStream $stream, $option, array $enums)
     {
-        $stream->consume([['symbol', '=']]);
+        $stream->consume([[Token::SYMBOL, '=']]);
         $token = $stream->nextToken();
-        if (!in_array($token->type, ['identifier', 'number'])) {
+        if (!in_array($token->type, [Token::IDENTIFIER, Token::NUMBER])) {
             throw new \RuntimeException("Bad table option value");
         }
         $value = strtoupper($token->text);
@@ -260,7 +260,7 @@ class TableOptions
      */
     private function _parseString(TokenStream $stream, $option)
     {
-        $stream->consume([['symbol', '=']]);
+        $stream->consume([[Token::SYMBOL, '=']]);
         $this->setOption($option, $stream->expectString());
     }
 

--- a/tests/Parse/TokenStreamTest.php
+++ b/tests/Parse/TokenStreamTest.php
@@ -55,58 +55,58 @@ class TokenStreamTest extends TestCase
         $bs = "\\";
 
         return [
-            [ '',          'EOF',    ''          ],
+            [ '',          Token::EOF,    ''          ],
 
             // numbers
-            [ '1',         'number', '1'         ],
-            [ '123',       'number', '123'       ],
-            [ '123.45',    'number', '123.45'    ],
-            [ '.45',       'number', '.45'       ],
-            [ '123.',      'number', '123.'      ],
-            [ '-123',      'number', '-123'      ],
-            [ '+123',      'number', '+123'      ],
-            [ '1E23',      'number', '1E23'      ],
-            [ '1e23',      'number', '1e23'      ],
-            [ '1e+23',     'number', '1e+23'     ],
-            [ '1e-23',     'number', '1e-23'     ],
-            [ '+1.23e-17', 'number', '+1.23e-17' ],
+            [ '1',         Token::NUMBER, '1'         ],
+            [ '123',       Token::NUMBER, '123'       ],
+            [ '123.45',    Token::NUMBER, '123.45'    ],
+            [ '.45',       Token::NUMBER, '.45'       ],
+            [ '123.',      Token::NUMBER, '123.'      ],
+            [ '-123',      Token::NUMBER, '-123'      ],
+            [ '+123',      Token::NUMBER, '+123'      ],
+            [ '1E23',      Token::NUMBER, '1E23'      ],
+            [ '1e23',      Token::NUMBER, '1e23'      ],
+            [ '1e+23',     Token::NUMBER, '1e+23'     ],
+            [ '1e-23',     Token::NUMBER, '1e-23'     ],
+            [ '+1.23e-17', Token::NUMBER, '+1.23e-17' ],
 
             // whitespace
-            [ " 1",  'number', 1],
-            [ "\t1", 'number', 1],
-            [ "\n1", 'number', 1],
+            [ " 1",  Token::NUMBER, 1],
+            [ "\t1", Token::NUMBER, 1],
+            [ "\n1", Token::NUMBER, 1],
 
             // comments
-            [ "/*comment*/1",   'number', '1'],
-            [ "/**/1",          'number', '1'],
-            [ "-- comment\n1",  'number', '1'],
-            [ "--\n1",          'number', '1'],
-            [ "#comment\n1",    'number', '1'],
+            [ "/*comment*/1",   Token::NUMBER, '1'],
+            [ "/**/1",          Token::NUMBER, '1'],
+            [ "-- comment\n1",  Token::NUMBER, '1'],
+            [ "--\n1",          Token::NUMBER, '1'],
+            [ "#comment\n1",    Token::NUMBER, '1'],
 
             // conditional comments
-            [ "/*! 12345*/",      'number', '12345'],
-            [ "/*!12345 12345*/", 'number', '12345'],
+            [ "/*! 12345*/",      Token::NUMBER, '12345'],
+            [ "/*!12345 12345*/", Token::NUMBER, '12345'],
 
             // double quoted strings
-            [ "{$dq}{$dq}",                     'string', ''],
-            [ "{$dq}hello world{$dq}",          'string', 'hello world'],
-            [ "{$dq}hello{$dq}{$dq}world{$dq}", 'string', "hello{$dq}world"],     // "" => "
-            [ "{$dq}hello{$bs}{$bs}world{$dq}", 'string', "hello{$bs}world"],     // \\ => \
-            [ "{$dq}hello{$bs}{$dq}world{$dq}", 'string', "hello{$dq}world"],     // \" => "
+            [ "{$dq}{$dq}",                     Token::STRING, ''],
+            [ "{$dq}hello world{$dq}",          Token::STRING, 'hello world'],
+            [ "{$dq}hello{$dq}{$dq}world{$dq}", Token::STRING, "hello{$dq}world"],     // "" => "
+            [ "{$dq}hello{$bs}{$bs}world{$dq}", Token::STRING, "hello{$bs}world"],     // \\ => \
+            [ "{$dq}hello{$bs}{$dq}world{$dq}", Token::STRING, "hello{$dq}world"],     // \" => "
 
             // single quoted strings
-            [ "{$sq}{$sq}",                     'string', ''],
-            [ "{$sq}hello{$sq}",                'string', 'hello'],
-            [ "{$sq}hello{$sq}{$sq}world{$sq}", 'string', "hello{$sq}world"],     // '' => '
-            [ "{$sq}hello{$bs}{$bs}world{$sq}", 'string', "hello{$bs}world"],     // \\ => \
-            [ "{$sq}hello{$bs}{$sq}world{$sq}", 'string', "hello{$sq}world"],     // \' => '
+            [ "{$sq}{$sq}",                     Token::STRING, ''],
+            [ "{$sq}hello{$sq}",                Token::STRING, 'hello'],
+            [ "{$sq}hello{$sq}{$sq}world{$sq}", Token::STRING, "hello{$sq}world"],     // '' => '
+            [ "{$sq}hello{$bs}{$bs}world{$sq}", Token::STRING, "hello{$bs}world"],     // \\ => \
+            [ "{$sq}hello{$bs}{$sq}world{$sq}", Token::STRING, "hello{$sq}world"],     // \' => '
 
             // backquoted identifiers
-            [ "{$bq}{$bq}",                     'identifier', ''],
-            [ "{$bq}hello{$bq}",                'identifier', 'hello'],
-            [ "{$bq}hello{$bq}{$bq}world{$bq}", 'identifier', "hello{$bq}world"],      // `` => `
-            [ "{$bq}hello{$bs}{$bs}world{$bq}", 'identifier', "hello{$bs}${bs}world"], // \\ => \\
-            [ "{$bq}hello{$bs}nworld{$bq}",     'identifier', "hello{$bs}nworld"],     // \n => \n
+            [ "{$bq}{$bq}",                     Token::IDENTIFIER, ''],
+            [ "{$bq}hello{$bq}",                Token::IDENTIFIER, 'hello'],
+            [ "{$bq}hello{$bq}{$bq}world{$bq}", Token::IDENTIFIER, "hello{$bq}world"],      // `` => `
+            [ "{$bq}hello{$bs}{$bs}world{$bq}", Token::IDENTIFIER, "hello{$bs}${bs}world"], // \\ => \\
+            [ "{$bq}hello{$bs}nworld{$bq}",     Token::IDENTIFIER, "hello{$bs}nworld"],     // \n => \n
 
             // hex literals
             [ "x''",                    "hex", "" ],
@@ -120,15 +120,15 @@ class TokenStreamTest extends TestCase
             [ "b'00011011'",    "bin", "00011011" ],
 
             // unquoted identifiers
-       //   [ '1_',       'identifier', '1_' ],     // TODO - make this pass
-            [ '_',        'identifier', '_' ],
-            [ '$',        'identifier', '$' ],
-            [ 'a',        'identifier', 'a' ],
-            [ 'abc',      'identifier', 'abc' ],
-            [ 'abc123',   'identifier', 'abc123' ],
-            [ '_abc',     'identifier', '_abc' ],
-            [ '_123',     'identifier', '_123' ],
-            [ '$_123abc', 'identifier', '$_123abc' ],
+       //   [ '1_',       Token::IDENTIFIER, '1_' ],     // TODO - make this pass
+            [ '_',        Token::IDENTIFIER, '_' ],
+            [ '$',        Token::IDENTIFIER, '$' ],
+            [ 'a',        Token::IDENTIFIER, 'a' ],
+            [ 'abc',      Token::IDENTIFIER, 'abc' ],
+            [ 'abc123',   Token::IDENTIFIER, 'abc123' ],
+            [ '_abc',     Token::IDENTIFIER, '_abc' ],
+            [ '_123',     Token::IDENTIFIER, '_123' ],
+            [ '$_123abc', Token::IDENTIFIER, '$_123abc' ],
 
             // symbols
             [ "<=_", "symbol", "<=" ],
@@ -189,14 +189,14 @@ class TokenStreamTest extends TestCase
     public function consumeProvider()
     {
         return [
-            ['create table t', 'create',          true,  'identifier', 'table'],
-            ['create table t', 'create table',    true,  'identifier', 't'],
-            ['create table t', 'drop',            false, 'identifier', 'create'],
-            ['create table t', 'drop table',      false, 'identifier', 'create'],
-            ['create table t', 'create database', false, 'identifier', 'create'],
-            ['= "test"',       [['symbol', '=']], true,  'string', 'test'],
-            ['();',            [['symbol', '('],
-                                ['symbol', ')']], true,  'symbol', ';'],
+            ['create table t', 'create',          true,  Token::IDENTIFIER, 'table'],
+            ['create table t', 'create table',    true,  Token::IDENTIFIER, 't'],
+            ['create table t', 'drop',            false, Token::IDENTIFIER, 'create'],
+            ['create table t', 'drop table',      false, Token::IDENTIFIER, 'create'],
+            ['create table t', 'create database', false, Token::IDENTIFIER, 'create'],
+            ['= "test"',       [[Token::SYMBOL, '=']], true,  Token::STRING, 'test'],
+            ['();',            [[Token::SYMBOL, '('],
+                                [Token::SYMBOL, ')']], true,  Token::SYMBOL, ';'],
         ];
     }
 
@@ -226,28 +226,28 @@ class TokenStreamTest extends TestCase
     public function peekProvider()
     {
         return [
-            ['create table t', 'create',          true,  'identifier', 'create'],
-            ['create table t', 'create table',    true,  'identifier', 'create'],
-            ['create table t', 'drop',            false, 'identifier', 'create'],
-            ['create table t', 'drop table',      false, 'identifier', 'create'],
-            ['create table t', 'create database', false, 'identifier', 'create'],
-            ['= "test"',       [['symbol', '=']], true,  'symbol', '='],
-            ['();',            [['symbol', '('],
-                                ['symbol', ')']], true,  'symbol', '('],
+            ['create table t', 'create',          true,  Token::IDENTIFIER, 'create'],
+            ['create table t', 'create table',    true,  Token::IDENTIFIER, 'create'],
+            ['create table t', 'drop',            false, Token::IDENTIFIER, 'create'],
+            ['create table t', 'drop table',      false, Token::IDENTIFIER, 'create'],
+            ['create table t', 'create database', false, Token::IDENTIFIER, 'create'],
+            ['= "test"',       [[Token::SYMBOL, '=']], true,  Token::SYMBOL, '='],
+            ['();',            [[Token::SYMBOL, '('],
+                                [Token::SYMBOL, ')']], true,  Token::SYMBOL, '('],
         ];
     }
 
     public function testExpectSucc()
     {
         $stream = $this->makeStream('create table t');
-        $stream->expect('identifier', 'create');
+        $stream->expect(Token::IDENTIFIER, 'create');
     }
 
     /** @expectedException \Exception */
     public function testExpectFail()
     {
         $stream = $this->makeStream('create table t');
-        $stream->expect('identifier', 'drop');
+        $stream->expect(Token::IDENTIFIER, 'drop');
     }
 
     // TODO -

--- a/tests/Parse/TokenTest.php
+++ b/tests/Parse/TokenTest.php
@@ -8,23 +8,23 @@ class TokenTest extends TestCase
 {
     public function testIsEof()
     {
-        $eof = new Token('EOF');
+        $eof = new Token(Token::EOF);
         $this->assertTrue($eof->isEof());
 
-        $notEof = new Token('number', '123');
+        $notEof = new Token(Token::NUMBER, '123');
         $this->assertFalse($notEof->isEof());
     }
 
     public function testEq()
     {
-        $token = new Token('string', 'test');
+        $token = new Token(Token::STRING, 'test');
 
-        $this->assertTrue($token->eq('string', 'test'));
-        $this->assertTrue($token->eq('string', 'Test'));
-        $this->assertTrue($token->eq('string', 'TEST'));
+        $this->assertTrue($token->eq(Token::STRING, 'test'));
+        $this->assertTrue($token->eq(Token::STRING, 'Test'));
+        $this->assertTrue($token->eq(Token::STRING, 'TEST'));
 
-        $this->assertFalse($token->eq('string', 'testtest'));
-        $this->assertFalse($token->eq('number', 'test'));
+        $this->assertFalse($token->eq(Token::STRING, 'testtest'));
+        $this->assertFalse($token->eq(Token::NUMBER, 'test'));
     }
 
     public function testMakeStringEscapes()
@@ -45,7 +45,7 @@ class TokenTest extends TestCase
         );
         $this->assertTrue(
             $escaped->eq(
-                'string',
+                Token::STRING,
                 "bcd{$bs}" .
                 "cde" . chr(0) .
                 "def" . chr(8) .
@@ -78,7 +78,7 @@ class TokenTest extends TestCase
         );
         $this->assertTrue(
             $unescaped->eq(
-                'string',
+                Token::STRING,
                 "ijk" . "a" .
                 "jkl" . "f" .
                 "klm" . "${sq}" .
@@ -102,11 +102,11 @@ class TokenTest extends TestCase
             "{$sq}${sq}abc" => "{$sq}abc",
         ] as $arg => $result) {
             $token = Token::fromString($arg, $sq);
-            $this->assertTrue($token->eq('string', $result));
+            $this->assertTrue($token->eq(Token::STRING, $result));
         }
 
         $token = Token::fromString("{$sq}${sq}", $sq);
-        $this->assertTrue($token->eq('string', "{$sq}"));
+        $this->assertTrue($token->eq(Token::STRING, "{$sq}"));
     }
 
     public function testMakeIdentifier()
@@ -126,7 +126,7 @@ class TokenTest extends TestCase
 
         $this->assertTrue(
             $token->eq(
-                'identifier',
+                Token::IDENTIFIER,
                 'abc`def' .
                 "{$bs}0" .
                 "{$bs}b" .
@@ -221,54 +221,54 @@ class TokenTest extends TestCase
     public function providerAsXyz()
     {
         return [
-            ['asString',   'string', 'abc',                 'abc'    ],
-            ['asString',   'string', '',                    ''       ],
+            ['asString',   Token::STRING, 'abc',                 'abc'    ],
+            ['asString',   Token::STRING, '',                    ''       ],
 
-            ['asString',   'number', '123',                 '123'    ],
-            ['asString',   'number', '0123',                '123'    ],
-            ['asString',   'number', '-0123',               '-123'   ],
-            ['asString',   'number', '1.2300',              '1.2300' ],
-            ['asString',   'number', '1.234567890123',      '1.234567890123' ],
-            ['asString',   'number', '-1.23',               '-1.23'  ],
-            ['asString',   'number', '+1.23',               '1.23'   ],
-            ['asString',   'number', '.23',                 '0.23'   ],
-            ['asString',   'number', '',                    '0'      ],
+            ['asString',   Token::NUMBER, '123',                 '123'    ],
+            ['asString',   Token::NUMBER, '0123',                '123'    ],
+            ['asString',   Token::NUMBER, '-0123',               '-123'   ],
+            ['asString',   Token::NUMBER, '1.2300',              '1.2300' ],
+            ['asString',   Token::NUMBER, '1.234567890123',      '1.234567890123' ],
+            ['asString',   Token::NUMBER, '-1.23',               '-1.23'  ],
+            ['asString',   Token::NUMBER, '+1.23',               '1.23'   ],
+            ['asString',   Token::NUMBER, '.23',                 '0.23'   ],
+            ['asString',   Token::NUMBER, '',                    '0'      ],
 
         // TODO - work is needed on Token::asString to make these tests parse:
-        //  ['asString',   'number', '1.234e1',             '12.34'  ],
-        //  ['asString',   'number', '1.234000e15',         '1.234e15' ],
-        //  ['asString',   'number', '0.999999e15',         '999999000000000' ],
-        //  ['asString',   'number', '-1.234000e15',        '-1.234e15' ],
-        //  ['asString',   'number', '-0.999999e15',        '-999999000000000'],
-        //  ['asString',   'number', '1.0001e-15',          '0.0000000000000010001' ],
-        //  ['asString',   'number', '0.999e-16',           '9.99e-16' ],
-        //  ['asString',   'number', '-1.0001e-15',         '-0.0000000000000010001' ],
-        //  ['asString',   'number', '-0.999e-16',          '-9.99e-16' ],
+        //  ['asString',   Token::NUMBER, '1.234e1',             '12.34'  ],
+        //  ['asString',   Token::NUMBER, '1.234000e15',         '1.234e15' ],
+        //  ['asString',   Token::NUMBER, '0.999999e15',         '999999000000000' ],
+        //  ['asString',   Token::NUMBER, '-1.234000e15',        '-1.234e15' ],
+        //  ['asString',   Token::NUMBER, '-0.999999e15',        '-999999000000000'],
+        //  ['asString',   Token::NUMBER, '1.0001e-15',          '0.0000000000000010001' ],
+        //  ['asString',   Token::NUMBER, '0.999e-16',           '9.99e-16' ],
+        //  ['asString',   Token::NUMBER, '-1.0001e-15',         '-0.0000000000000010001' ],
+        //  ['asString',   Token::NUMBER, '-0.999e-16',          '-9.99e-16' ],
 
-            ['asString',   'hex',    '68656c6c6f21',        'hello!' ],
-            ['asString',   'bin',    '0111111000100011',    '~#'     ],
+            ['asString',   Token::HEX,    '68656c6c6f21',        'hello!' ],
+            ['asString',   Token::BIN,    '0111111000100011',    '~#'     ],
 
-            ['asNumber',   'string', '123',                 123   ],
-            ['asNumber',   'number', '456',                 456   ],
-            ['asNumber',   'hex',    'fffe',                65534 ],
-            ['asNumber',   'bin',    '10100101',            165   ],
+            ['asNumber',   Token::STRING, '123',                 123   ],
+            ['asNumber',   Token::NUMBER, '456',                 456   ],
+            ['asNumber',   Token::HEX,    'fffe',                65534 ],
+            ['asNumber',   Token::BIN,    '10100101',            165   ],
 
-            ['asDate',     'string', '0',                   '0000-00-00'],
-            ['asDate',     'string', '0000-00-00',          '0000-00-00'],
-            ['asDate',     'string', '1970-08-12',          '1970-08-12'],
-            ['asDate',     'string', '2001-12-31',          '2001-12-31'],
+            ['asDate',     Token::STRING, '0',                   '0000-00-00'],
+            ['asDate',     Token::STRING, '0000-00-00',          '0000-00-00'],
+            ['asDate',     Token::STRING, '1970-08-12',          '1970-08-12'],
+            ['asDate',     Token::STRING, '2001-12-31',          '2001-12-31'],
 
-            ['asTime',     'string', '0',                   '00:00:00'  ],
-            ['asTime',     'string', '00:00:00',            '00:00:00'  ],
-            ['asTime',     'string', '17:45:59',            '17:45:59'  ],
+            ['asTime',     Token::STRING, '0',                   '00:00:00'  ],
+            ['asTime',     Token::STRING, '00:00:00',            '00:00:00'  ],
+            ['asTime',     Token::STRING, '17:45:59',            '17:45:59'  ],
 
-            ['asDateTime', 'string', '0',                   '0000-00-00 00:00:00'],
-            ['asDateTime', 'string', '0000-00-00',          '0000-00-00 00:00:00'],
-            ['asDateTime', 'string', '1970-08-12',          '1970-08-12 00:00:00'],
-            ['asDateTime', 'string', '2001-12-31',          '2001-12-31 00:00:00'],
-            ['asDateTime', 'string', '0000-00-00 00:00:00', '0000-00-00 00:00:00'],
-            ['asDateTime', 'string', '1970-08-12 13:34:45', '1970-08-12 13:34:45'],
-            ['asDateTime', 'string', '2001-12-31 23:59:59', '2001-12-31 23:59:59'],
+            ['asDateTime', Token::STRING, '0',                   '0000-00-00 00:00:00'],
+            ['asDateTime', Token::STRING, '0000-00-00',          '0000-00-00 00:00:00'],
+            ['asDateTime', Token::STRING, '1970-08-12',          '1970-08-12 00:00:00'],
+            ['asDateTime', Token::STRING, '2001-12-31',          '2001-12-31 00:00:00'],
+            ['asDateTime', Token::STRING, '0000-00-00 00:00:00', '0000-00-00 00:00:00'],
+            ['asDateTime', Token::STRING, '1970-08-12 13:34:45', '1970-08-12 13:34:45'],
+            ['asDateTime', Token::STRING, '2001-12-31 23:59:59', '2001-12-31 23:59:59'],
         ];
     }
 
@@ -290,25 +290,25 @@ class TokenTest extends TestCase
     public function providerAsXyzError()
     {
         return [
-            ['asDate',     'string', 'abc'       ],
-            ['asDate',     'string', '1970'      ],
-            ['asDate',     'string', '19700812'  ],
-            ['asDate',     'string', '1970/08/12'],
+            ['asDate',     Token::STRING, 'abc'       ],
+            ['asDate',     Token::STRING, '1970'      ],
+            ['asDate',     Token::STRING, '19700812'  ],
+            ['asDate',     Token::STRING, '1970/08/12'],
 
-            ['asTime',     'string', 'abc'       ],
-            ['asTime',     'string', '000000'    ],
-            ['asTime',     'string', '1745'      ],
-            ['asTime',     'string', '174559'    ],
+            ['asTime',     Token::STRING, 'abc'       ],
+            ['asTime',     Token::STRING, '000000'    ],
+            ['asTime',     Token::STRING, '1745'      ],
+            ['asTime',     Token::STRING, '174559'    ],
 
-            ['asDateTime', 'string', 'abc'           ],
-            ['asDateTime', 'string', '19700812'      ],
-            ['asDateTime', 'string', '1970/08/12'    ],
-            ['asDateTime', 'string', '197008120000'  ],
-            ['asDateTime', 'string', '19700812000000'],
+            ['asDateTime', Token::STRING, 'abc'           ],
+            ['asDateTime', Token::STRING, '19700812'      ],
+            ['asDateTime', Token::STRING, '1970/08/12'    ],
+            ['asDateTime', Token::STRING, '197008120000'  ],
+            ['asDateTime', Token::STRING, '19700812000000'],
 
-            ['asString',   'symbol', 'abc'       ],
+            ['asString',   Token::SYMBOL, 'abc'       ],
 
-            ['asNumber',   'symbol', 'abc'       ],
+            ['asNumber',   Token::SYMBOL, 'abc'       ],
         ];
     }
 


### PR DESCRIPTION
Replace token type strings with their const equivalents (eg. `'number'` -> `Token::NUMBER`).