### PR TITLE
Adding some explicit support for PHP 7.1 and 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
     - 5.6
     - 7.0
     - 7.1
+    - 7.2
 
 before_script:
     - travis_retry composer update --no-interaction

--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,13 @@ lint: ## Run phpcs against the code.
 	@docker-compose run --rm php vendor/bin/phpcs -p --warning-severity=0 src/ tests/
 
 test-coverage: ## Run all tests and output coverage to the console.
-	@docker-compose run --rm php phpdbg -qrr vendor/bin/phpunit --coverage-text
+	@docker-compose run --rm php-71 phpdbg -qrr vendor/bin/phpunit --coverage-text
 
 test-coverage-html: ## Run all tests and output html results
-	@docker-compose run --rm php phpdbg -qrr vendor/bin/phpunit --coverage-html ./tests/report/html
+	@docker-compose run --rm php-71 phpdbg -qrr vendor/bin/phpunit --coverage-html ./tests/report/html
 
 test-coverage-clover: ## Run all tests and output clover coverage to file.
-	@docker-compose run --rm php phpdbg -qrr vendor/bin/phpunit --coverage-clover=./tests/report/coverage.clover
+	@docker-compose run --rm php-71 phpdbg -qrr vendor/bin/phpunit --coverage-clover=./tests/report/coverage.clover
 
 start-db: ## Start up the test database
 	@docker-compose up -d db

--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,13 @@ test: ## Run test suite
 test: lint
 	@test -f ./vendor/bin/phpunit || ${MAKE} install
 	@docker-compose run --rm php    ./vendor/bin/phpunit --testsuite tests
+	@docker-compose run --rm php-71 ./vendor/bin/phpunit --testsuite tests
 	@docker-compose run --rm php-70 ./vendor/bin/phpunit --testsuite tests
 	@docker-compose run --rm php-56 ./vendor/bin/phpunit --testsuite tests
 	@docker-compose run --rm php-55 ./vendor/bin/phpunit --testsuite tests
 
 lint: ## Run phpcs against the code.
-	@docker-compose run --rm php-55 vendor/bin/phpcs -p --warning-severity=0 src/ tests/
+	@docker-compose run --rm php vendor/bin/phpcs -p --warning-severity=0 src/ tests/
 
 test-coverage: ## Run all tests and output coverage to the console.
 	@docker-compose run --rm php phpdbg -qrr vendor/bin/phpunit --coverage-text

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,12 @@ services:
             - .:/usr/src/app
         working_dir: /usr/src/app
 
+    php-71:
+        image: php:7.1-alpine
+        volumes:
+            - .:/usr/src/app
+        working_dir: /usr/src/app
+
     php-70:
         image: php:7.0-alpine
         volumes:


### PR DESCRIPTION
The local dev stuff uses the latest version of PHP, whatever that might be. Previously this was 7.1 and is now 7.2. This PR adds some explicit support for both of these.

The version being used for code coverage though is being kept at 7.1 because for some reason, 7.2 is marking all case statements as being not covered.

Example from `TableOptions.php`:

![image](https://user-images.githubusercontent.com/1482649/34469794-ccf1f1e0-ef1d-11e7-932c-0544923edefc.png)
