### PR TITLE
Add utf8mb4 to supported character sets

### DIFF
--- a/src/Parse/CollationInfo.php
+++ b/src/Parse/CollationInfo.php
@@ -27,6 +27,11 @@ class CollationInfo
             'utf8_unicode_ci',
             'utf8_bin',
         ],
+        'utf8mb4' => [
+            'utf8mb4_general_ci',
+            'utf8mb4_unicode_ci',
+            'utf8mb4_bin',
+        ],
         'binary' => [
             'binary',
         ],


### PR DESCRIPTION
Adding support for utf8mb4 charset and collations, so that we can store 4-byte symbols. 