### PR TITLE
fix commands for updated symfony

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,5 +15,5 @@ services:
     image: graze/php-alpine:7.2
     volumes:
       - .:/src
-    command:
+    entrypoint:
       - /src/bin/morphism

--- a/src/Command/Diff.php
+++ b/src/Command/Diff.php
@@ -107,7 +107,7 @@ class Diff extends Command
         $this->addArgument(
             self::ARGUMENT_CONNECTIONS,
             InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
-            null,
+            '',
             []
         );
 
@@ -141,7 +141,7 @@ class Diff extends Command
             self::OPTION_APPLY_CHANGES,
             null,
             InputOption::VALUE_REQUIRED,
-            null,
+            '',
             "no"
         );
 

--- a/src/Command/Extract.php
+++ b/src/Command/Extract.php
@@ -60,7 +60,7 @@ class Extract extends Command
         $this->addArgument(
             self::ARGUMENT_MYSQL_DUMP_FILE,
             InputArgument::OPTIONAL,
-            null,
+            '',
             'php://stdin'
         );
 
@@ -68,7 +68,7 @@ class Extract extends Command
             self::OPTION_SCHEMA_PATH,
             null,
             InputOption::VALUE_REQUIRED,
-            null,
+            '',
             './schema'
         );
 

--- a/src/Command/Fastdump.php
+++ b/src/Command/Fastdump.php
@@ -71,7 +71,7 @@ class Fastdump extends Command
         $this->addArgument(
             self::ARGUMENT_CONNECTIONS,
             InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
-            null,
+            '',
             []
         );
 

--- a/src/Command/Lint.php
+++ b/src/Command/Lint.php
@@ -53,7 +53,7 @@ class Lint extends Command
         $this->addArgument(
             self::ARGUMENT_PATH,
             InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
-            null,
+            '',
             ['php://stdin']
         );
 


### PR DESCRIPTION
the symfony version updates broke some of the commands.

- Fixes the commands with changes required for `Symfony/Console`.