### PR TITLE
Support for multiple schema directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /ocular.phar
 /phpunit.xml
 /schema
+/schema2
 /tests/report
 /vendor
 .idea/

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ test: ## Run the unit and integration testsuites.
 test: lint test-unit
 
 lint: ## Run phpcs against the code.
-	${DOCKER_RUN} vendor/bin/phpcs -p --warning-severity=0 src/ tests/
+	${DOCKER_RUN} vendor/bin/phpcs -p --colors --extensions=php --warning-severity=0 --ignore=*/vendor/* src/ tests/
 
 lint-fix: ## Run phpcsf and fix possible lint errors.
 	${DOCKER_RUN} vendor/bin/phpcbf -p src/ tests/

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,15 @@ test-coverage-html: ## Run all tests and output coverage to html.
 test-coverage-clover: ## Run all tests and output clover coverage to file.
 	${DOCKER_RUN} phpdbg7 -qrr vendor/bin/phpunit --coverage-clover=./tests/report/coverage.clover
 
+.PHONY: example
+example: ## Set up example project and schema
+	[ ! -f morphism.conf ] && cp example/morphism.conf.example morphism.conf || true
+	rm -rf schema schema2
+	mkdir -p schema/morphism-test schema2/morphism-test
+	cp example/schema/product.sql example/schema/ingredient.sql schema/morphism-test
+	cp example/schema/product_ingredient_map.sql schema2/morphism-test
+	docker-compose run --rm morphism diff --apply-changes yes morphism.conf
+
 # Database
 
 start-db: ## Start up the test database

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ databases:
             enable: true
             # Path where schema files live.
             # Defaults to "schema/<connection-name>"
-            schemaDefinitionPath: schema/catalog
+            schemaDefinitionPath:
+                - schema/catalog
             # you may optionally specify one or more regexes matching tables
             # to exclude (any changes, creation or deletion of matching tables
             # will be ignored). The regex must match the entire table name, i.e.

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ $ docker run --rm graze/morphism
 ### Examples:
 
 ```bash
-$ docker run --rm -v $PWD/config:/app/config -v $PWD/schema:/app/schema:cached graze/morphsim diff config/morphism.yml
-$ docker run --rm -v $PWD/config:/app/config -v $PWD/schema:/app/schema:delegated graze/morphsim dump config/morphism.yml
+$ docker run --rm -v $PWD/config:/app/config -v $PWD/schema:/app/schema:cached graze/morphism diff config/morphism.yml
+$ docker run --rm -v $PWD/config:/app/config -v $PWD/schema:/app/schema:delegated graze/morphism dump config/morphism.yml
 ```
 
 ### Attaching to an existing network when developing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,6 @@ services:
   morphism:
     image: graze/php-alpine:7.2
     volumes:
-      - .:/src
+      - .:/srv
     entrypoint:
-      - /src/bin/morphism
+      - /srv/bin/morphism

--- a/example/morphism.conf.example
+++ b/example/morphism.conf.example
@@ -17,9 +17,12 @@ databases:
         morphism:
             # morphism diff only operates on connections with 'enable: true'
             enable: true
-            # Path where schema files live.
+            # Path(s) where schema files live.
+            # This can be a single directory or multiple directories
             # Defaults to "schema/<connection-name>"
-            schemaDefinitionPath: schema/morphism-test
+            schemaDefinitionPath:
+                - schema/morphism-test
+                - schema2/morphism-test
             # you may optionally specify one or more regexes matching tables
             # to exclude (any changes, creation or deletion of matching tables
             # will be ignored). The regex must match the entire table name, i.e.

--- a/example/schema/product_ingredient_map.sql
+++ b/example/schema/product_ingredient_map.sql
@@ -1,6 +1,6 @@
 CREATE TABLE `product_ingredient_map` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `product_id` int(11) unsigned NOT NULL REFERENCES product(id),
-  `ingredient_id` int(11) NOT NULL REFERENCES ingredient(id),
+  `product_id` int(11) unsigned NOT NULL,
+  `ingredient_id` int(11) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/src/Command/Diff.php
+++ b/src/Command/Diff.php
@@ -347,9 +347,6 @@ class Diff extends Command
                 $entry = $config->getEntry($connectionName);
                 $dbName = $entry['connection']['dbname'];
                 $schemaDefinitionPaths = $entry['morphism']['schemaDefinitionPath'];
-                if (! is_array($schemaDefinitionPaths)) {
-                    $schemaDefinitionPaths = [$schemaDefinitionPaths];
-                }
                 $matchTables = [
                     $dbName => $entry['morphism']['matchTables'],
                 ];

--- a/src/Command/Diff.php
+++ b/src/Command/Diff.php
@@ -181,15 +181,15 @@ class Diff extends Command
     }
 
     /**
-     * @param string $schemaDefinitionPath
+     * @param string[] $schemaDefinitionPaths
      * @param string $dbName
      *
      * @return MySqlDump
      */
-    private function getTargetSchema($schemaDefinitionPath, $dbName)
+    private function getTargetSchema(array $schemaDefinitionPaths, $dbName)
     {
         return MysqlDump::parseFromPaths(
-            [$schemaDefinitionPath],
+            $schemaDefinitionPaths,
             $this->engine,
             $this->collation,
             $dbName
@@ -346,13 +346,16 @@ class Diff extends Command
                 $connection = $config->getConnection($connectionName);
                 $entry = $config->getEntry($connectionName);
                 $dbName = $entry['connection']['dbname'];
-                $schemaDefinitionPath = $entry['morphism']['schemaDefinitionPath'];
+                $schemaDefinitionPaths = $entry['morphism']['schemaDefinitionPath'];
+                if (! is_array($schemaDefinitionPaths)) {
+                    $schemaDefinitionPaths = [$schemaDefinitionPaths];
+                }
                 $matchTables = [
                     $dbName => $entry['morphism']['matchTables'],
                 ];
 
                 $currentSchema = $this->getCurrentSchema($connection, $dbName);
-                $targetSchema = $this->getTargetSchema($schemaDefinitionPath, $dbName);
+                $targetSchema = $this->getTargetSchema($schemaDefinitionPaths, $dbName);
 
                 $diff = $currentSchema->diff(
                     $targetSchema,

--- a/src/Command/Fastdump.php
+++ b/src/Command/Fastdump.php
@@ -113,7 +113,10 @@ class Fastdump extends Command
             $entry = $config->getEntry($connectionName);
             $dbName = $entry['connection']['dbname'];
             $matchTables = $entry['morphism']['matchTables'];
-            $schemaDefinitionPath = $entry['morphism']['schemaDefinitionPath'];
+            $schemaDefinitionPaths = $entry['morphism']['schemaDefinitionPath'];
+            if (! is_array($schemaDefinitionPaths)) {
+                $schemaDefinitionPaths = [$schemaDefinitionPaths];
+            }
 
             if (!$this->write) {
                 echo "\n";
@@ -141,20 +144,35 @@ class Fastdump extends Command
             }
 
             if ($this->write) {
-                if (!is_dir($schemaDefinitionPath)) {
-                    if (!@mkdir($schemaDefinitionPath, 0755, true)) {
-                        throw new RuntimeException("could not make directory $schemaDefinitionPath");
+                // Ensure the schema directories to write to exist
+                foreach ($schemaDefinitionPaths as $schemaPath) {
+                    if (!is_dir($schemaPath)) {
+                        if (!@mkdir($schemaPath, 0755, true)) {
+                            throw new RuntimeException("Could not make directory $schemaPath");
+                        }
                     }
                 }
                 $database = reset($dump->databases);
                 foreach ($database->tables as $table) {
-                    $path = "$schemaDefinitionPath/{$table->name}.sql";
+                    // Find any existing schema file. If it doesn't exist, use the first schema path.
+                    foreach ($schemaDefinitionPaths as $schemaPath) {
+                        $possiblePath = "$schemaPath/{$table->name}.sql";
+                        if (file_exists($possiblePath)) {
+                            $path = $possiblePath;
+                            break;
+                        }
+                    }
+
+                    if (! isset($path)) {
+                        $path = "{$schemaDefinitionPaths[0]}/{$table->name}.sql";
+                    }
+
                     $text = '';
                     foreach ($table->getDDL() as $query) {
                         $text .= "$query;\n\n";
                     }
                     if (false === @file_put_contents($path, $text)) {
-                        throw new RuntimeException("could not write $path");
+                        throw new RuntimeException("Could not write $path");
                     }
                     fprintf(STDERR, "wrote $path\n");
                 }

--- a/src/Command/Fastdump.php
+++ b/src/Command/Fastdump.php
@@ -114,9 +114,6 @@ class Fastdump extends Command
             $dbName = $entry['connection']['dbname'];
             $matchTables = $entry['morphism']['matchTables'];
             $schemaDefinitionPaths = $entry['morphism']['schemaDefinitionPath'];
-            if (! is_array($schemaDefinitionPaths)) {
-                $schemaDefinitionPaths = [$schemaDefinitionPaths];
-            }
 
             if (!$this->write) {
                 echo "\n";

--- a/src/Command/Fastdump.php
+++ b/src/Command/Fastdump.php
@@ -152,6 +152,8 @@ class Fastdump extends Command
                 $database = reset($dump->databases);
                 foreach ($database->tables as $table) {
                     // Find any existing schema file. If it doesn't exist, use the first schema path.
+                    $path = null;
+
                     foreach ($schemaDefinitionPaths as $schemaPath) {
                         $possiblePath = "$schemaPath/{$table->name}.sql";
                         if (file_exists($possiblePath)) {
@@ -160,7 +162,7 @@ class Fastdump extends Command
                         }
                     }
 
-                    if (! isset($path)) {
+                    if (! $path) {
                         $path = "{$schemaDefinitionPaths[0]}/{$table->name}.sql";
                     }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -63,7 +63,10 @@ class Config
 
             $schemaDefinitionPaths = $morphism['schemaDefinitionPath'];
             if (!$schemaDefinitionPaths) {
-                $schemaDefinitionPaths = [ 'schema/'.$connectionName ];
+                $schemaDefinitionPaths = 'schema/'.$connectionName;
+            }
+            if (! is_array($schemaDefinitionPaths)) {
+                $schemaDefinitionPaths = [ $schemaDefinitionPaths ];
             }
 
             $entries[$connectionName] = [

--- a/src/Config.php
+++ b/src/Config.php
@@ -61,16 +61,16 @@ class Config
                 $matchTables[$key] = $regex;
             }
 
-            $schemaDefinitionPath = $morphism['schemaDefinitionPath'];
-            if (!$schemaDefinitionPath) {
-                $schemaDefinitionPath = 'schema/'.$connectionName;
+            $schemaDefinitionPaths = $morphism['schemaDefinitionPath'];
+            if (!$schemaDefinitionPaths) {
+                $schemaDefinitionPaths = [ 'schema/'.$connectionName ];
             }
 
             $entries[$connectionName] = [
                 'connection' => $entry,
                 'morphism'   => [
                     'matchTables' => $matchTables,
-                    'schemaDefinitionPath' => $schemaDefinitionPath,
+                    'schemaDefinitionPath' => $schemaDefinitionPaths,
                 ],
             ];
         }

--- a/src/Config.php
+++ b/src/Config.php
@@ -2,6 +2,8 @@
 
 namespace Graze\Morphism;
 
+use RuntimeException;
+
 /**
  * A parser for config files
  */
@@ -27,11 +29,15 @@ class Config
      */
     public function parse()
     {
+        if (! file_exists($this->path)) {
+            throw new RuntimeException("Specified config file does not exist: {$this->path}");
+        }
+
         $parser = new \Symfony\Component\Yaml\Parser;
         $config = $parser->parse(file_get_contents($this->path));
 
         if (!isset($config['databases'])) {
-            throw new \RuntimeException("missing databases section in '{$this->path}'");
+            throw new RuntimeException("Missing databases section in '{$this->path}'");
         }
 
         $entries = [];
@@ -91,7 +97,7 @@ class Config
     public function getEntry($connectionName)
     {
         if (!isset($this->entries[$connectionName])) {
-            throw new \RuntimeException("unknown connection '$connectionName'");
+            throw new RuntimeException("Unknown connection '$connectionName'");
         }
 
         return $this->entries[$connectionName];


### PR DESCRIPTION
This PR adds support for schema definition files being spread across multiple directories.

# Changes
* The `schemaDefinitionPath` config property is now an array.
  - It will still accept a single value.
* Added multiple schema folder support to the `diff` command.
* Added multiple schema folder support to the `dump` command.
  - If a schema file exists for a given table in any schema directory, it will write out to that file.
  - If a schema file does not exist, it will be written out to the first schema directory.
* Added a new `example` build target for setting up an example directory structure and schema.

# QA

## Setup
* `make start-db example`

## `diff`

```
docker-compose run --rm morphism diff morphism.conf
```

Try out some of these:
- Changes to tables in `schema`
- Changes to tables in `schema2`
- New/removed tables in `schema`
- New/removed tables in `schema2`

## `dump`
```
docker-compose run --rm morphism dump --write morphism.conf
```

Try some of these out:
- Dump without any changes. Should write out files in both directories.
- Remove file from `schema2` (to emulate a new table). Should be written out to the `schema` directory.