### PR TITLE
Fix boolean columns clobbering subsequent tinyint columns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ test-coverage-clover: ## Run all tests and output clover coverage to file.
 
 .PHONY: example
 example: ## Set up example project and schema
+example: start-db
 	[ ! -f morphism.conf ] && cp example/morphism.conf.example morphism.conf || true
 	rm -rf schema schema2
 	mkdir -p schema/morphism-test schema2/morphism-test

--- a/src/Parse/ColumnDefinition.php
+++ b/src/Parse/ColumnDefinition.php
@@ -274,6 +274,8 @@ class ColumnDefinition
             case 'bool':
             case 'boolean':
                 $format = [1];
+                /* Take a copy so that edits don't make it back into the runtime cache. */
+                $typeInfo = clone $typeInfo;
                 $typeInfo->allowSign = false;
                 $typeInfo->allowZerofill = false;
                 break;


### PR DESCRIPTION
Fixes #54 

# QA
```
# Setup
make example

cat > schema/morphism-test/aaa.sql <<EOF
create table aaa (
  foo boolean
);
EOF

cat > schema/morphism-test/zzz.sql <<EOF
create table zzz (
  bar tinyint unsigned
);
EOF

# Test
docker-compose run --rm morphism diff morphism.conf
```

Expected output:
```
-- --------------------------------
--   Connection: morphism-test
-- --------------------------------
CREATE TABLE `aaa` (
  `foo` tinyint(1) DEFAULT NULL
) ENGINE=InnoDB;

CREATE TABLE `zzz` (
  `bar` tinyint(3) unsigned DEFAULT NULL
) ENGINE=InnoDB;
```