### PR TITLE
Implement foreign keys

### DIFF
--- a/src/Command/Diff.php
+++ b/src/Command/Diff.php
@@ -181,6 +181,9 @@ class Diff extends Command
 
         $dump = new MysqlDump();
         $dump->setDefaultDatabase($dbName);
+        // Disable adding indexes for foreign keys on the current schema, if the new schema doesn't have the foreign
+        // key then both the foreign key and the index would be dropped however the index won't exist.
+        $dump->setAddIndexForForeignKey(false);
         $dump->parse($stream);
 
         return $dump;

--- a/src/Parse/MysqlDump.php
+++ b/src/Parse/MysqlDump.php
@@ -25,6 +25,8 @@ class MysqlDump
     private $defaultEngine = 'InnoDB';
     /** @var CollationInfo */
     private $defaultCollation = null;
+    /** @var bool */
+    private $addIndexForForeignKey = true;
 
     /**
      * Constructor
@@ -105,6 +107,16 @@ class MysqlDump
     }
 
     /**
+     * Sets whether to add an index for each foreign key if one isn't defined, this is the default behaviour of MySQL.
+     *
+     * @param bool $addIndexForForeignKey
+     */
+    public function setAddIndexForForeignKey($addIndexForForeignKey)
+    {
+        $this->addIndexForForeignKey = $addIndexForForeignKey;
+    }
+
+    /**
      * Sets the default collation to assume when no collation or charset
      * is specified in CREATE DATABASE or CREATE TABLE.
      *
@@ -151,6 +163,7 @@ class MysqlDump
                 }
                 $table = new CreateTable($this->database->getCollation());
                 $table->setDefaultEngine($this->defaultEngine);
+                $table->setAddIndexForForeignKey($this->addIndexForForeignKey);
                 $table->parse($stream);
                 $stream->expect(Token::SYMBOL, ';');
 

--- a/tests/Parse/CreateTableTest.php
+++ b/tests/Parse/CreateTableTest.php
@@ -136,6 +136,7 @@ class CreateTableTest extends TestCase
 
         foreach ([
                     'columns.sql',
+                    'foreignKeys.sql',
                     'indexes.sql',
                     'simpleDiff.sql'
                  ] as $file) {

--- a/tests/Parse/CreateTableTest.php
+++ b/tests/Parse/CreateTableTest.php
@@ -115,6 +115,7 @@ class CreateTableTest extends TestCase
         $firstStream = $this->makeStream($firstTableText);
         $firstTable = new CreateTable($collation);
         $firstTable->setDefaultEngine('InnoDB');
+        $firstTable->setAddIndexForForeignKey(false);
         $firstTable->parse($firstStream);
 
         $secondStream = $this->makeStream($secondTableText);

--- a/tests/Parse/sql/diff/foreignKeys.sql
+++ b/tests/Parse/sql/diff/foreignKeys.sql
@@ -1,0 +1,62 @@
+-- test - Add unnamed foreign key
+create table t (
+    `ux` int(11) DEFAULT NULL
+);
+create table t (
+    `ux` int(11) DEFAULT NULL,
+    FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
+);
+ALTER TABLE `t`
+ADD KEY `ux` (`ux`),
+ADD CONSTRAINT `t_ibfk_1` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
+
+-- test - Add named foreign key
+create table t (
+    `ux` int(11) DEFAULT NULL
+);
+create table t (
+    `ux` int(11) DEFAULT NULL,
+    CONSTRAINT `forKey1` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
+);
+ALTER TABLE `t`
+ADD KEY `forKey1` (`ux`),
+ADD CONSTRAINT `forKey1` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
+
+-- test - Drop unnamed foreign key
+create table t (
+    `ux` int(11) DEFAULT NULL,
+    FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
+);
+create table t (
+    `ux` int(11) DEFAULT NULL
+);
+ALTER TABLE `t`
+DROP KEY `ux`,
+DROP FOREIGN KEY `t_ibfk_1`
+
+-- test - Drop named foreign key
+create table t (
+    `ux` int(11) DEFAULT NULL,
+    CONSTRAINT `forKey1` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
+);
+create table t (
+    `ux` int(11) DEFAULT NULL
+);
+ALTER TABLE `t`
+DROP KEY `forKey1`,
+DROP FOREIGN KEY `forKey1`
+
+-- test - Rename foreign key
+create table t (
+    `ux` int(11) DEFAULT NULL,
+    CONSTRAINT `foo` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
+);
+create table t (
+    `ux` int(11) DEFAULT NULL,
+    CONSTRAINT `bar` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
+);
+ALTER TABLE `t`
+DROP KEY `foo`,
+ADD KEY `bar` (`ux`),
+DROP FOREIGN KEY `foo`,
+ADD CONSTRAINT `bar` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)

--- a/tests/Parse/sql/diff/foreignKeys.sql
+++ b/tests/Parse/sql/diff/foreignKeys.sql
@@ -22,6 +22,29 @@ ALTER TABLE `t`
 ADD KEY `forKey1` (`ux`),
 ADD CONSTRAINT `forKey1` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
 
+-- test - Key automatically gets added for foreign key as per MySQL
+create table t (
+    `ux` int(11) DEFAULT NULL,
+    CONSTRAINT `forKey1` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
+);
+create table t (
+    `ux` int(11) DEFAULT NULL,
+    CONSTRAINT `forKey1` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
+);
+ALTER TABLE `t`
+ADD KEY `forKey1` (`ux`)
+
+-- test - Automatically added key already exists in the current table so no change is required
+create table t (
+    `ux` int(11) DEFAULT NULL,
+    KEY `forKey1` (`ux`),
+    CONSTRAINT `forKey1` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
+);
+create table t (
+    `ux` int(11) DEFAULT NULL,
+    CONSTRAINT `forKey1` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
+);
+
 -- test - Drop unnamed foreign key
 create table t (
     `ux` int(11) DEFAULT NULL,
@@ -31,7 +54,6 @@ create table t (
     `ux` int(11) DEFAULT NULL
 );
 ALTER TABLE `t`
-DROP KEY `ux`,
 DROP FOREIGN KEY `t_ibfk_1`
 
 -- test - Drop named foreign key
@@ -43,7 +65,6 @@ create table t (
     `ux` int(11) DEFAULT NULL
 );
 ALTER TABLE `t`
-DROP KEY `forKey1`,
 DROP FOREIGN KEY `forKey1`
 
 -- test - Rename foreign key
@@ -56,7 +77,6 @@ create table t (
     CONSTRAINT `bar` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
 );
 ALTER TABLE `t`
-DROP KEY `foo`,
 ADD KEY `bar` (`ux`),
 DROP FOREIGN KEY `foo`,
 ADD CONSTRAINT `bar` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)


### PR DESCRIPTION
### Summary

- Add support for adding and dropping foreign keys.
- Add `--no-foreign-key-checks` option to disable foreign key checks, this is required as tables referenced in foreign keys may be added after the foreign key.

### QA

- Add [foreign_key_test.sql.txt](https://github.com/graze/morphism/files/3437965/foreign_key_test.sql.txt) to the schema folder and remove .txt suffix.
- Run morphism, it should try to add the table but fail with `General error: 1215 Cannot add foreign key constraint`:
  `/bin/morphism  diff --no-alter-engine --apply-changes=confirm config.yml`
- Run morphism with foreign key checks disabled, the table should be added successfully:
  `/bin/morphism  diff --no-alter-engine --apply-changes=confirm --no-foreign-key-checks config.yml`
- Rename constraint `foreign_key_test_ibfk_1` to `foreign_key_test_ibfk_3`.
- Run morphism, `foreign_key_test_ibfk_1` should be dropped and `foreign_key_test_ibfk_3` added:
  `/bin/morphism  diff --no-alter-engine --apply-changes=confirm --no-foreign-key-checks config.yml`