### PR TITLE
Fix default column for Maria DB

### DIFF
--- a/src/Extractor.php
+++ b/src/Extractor.php
@@ -328,7 +328,8 @@ class Extractor
             } else {
                 $defColumn .= " NULL";
             }
-            if (!is_null($column->COLUMN_DEFAULT)) {
+            // Maria DB defines null default columns as string 'NULL' rather than null, these need to be ignored.
+            if (!is_null($column->COLUMN_DEFAULT) && !($column->IS_NULLABLE == 'YES' && $column->COLUMN_DEFAULT == 'NULL')) {
                 if (in_array($column->DATA_TYPE, ['timestamp', 'datetime']) &&
                     $column->COLUMN_DEFAULT == 'CURRENT_TIMESTAMP'
                 ) {


### PR DESCRIPTION
### Summary
Querying Maria DB information schema returns default column nulls are the string 'NULL', this needs to be treated as an actual null.