### PR TITLE
Remove int width and zerofill for > MySQL 8.0.19

### DIFF
--- a/example/schema/ingredient.sql
+++ b/example/schema/ingredient.sql
@@ -1,6 +1,6 @@
 CREATE TABLE `ingredient` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` int(11) NOT NULL,
+  `id` int NOT NULL AUTO_INCREMENT,
+  `name` int NOT NULL,
   `is_active` tinyint(1) NOT NULL,
   PRIMARY KEY (`id`),
   CONSTRAINT `is_active_binary` CHECK (is_active IN (0,1))

--- a/example/schema/product.sql
+++ b/example/schema/product.sql
@@ -1,7 +1,7 @@
 CREATE TABLE `product` (
-  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
   `name` text NOT NULL,
-  `description` int(11) unsigned NOT NULL,
+  `description` int unsigned NOT NULL,
   `weight` decimal(11,2) NOT NULL,
   `launch_date` date DEFAULT NULL,
   `internal_note` text,

--- a/example/schema/product_ingredient_map.sql
+++ b/example/schema/product_ingredient_map.sql
@@ -1,6 +1,6 @@
 CREATE TABLE `product_ingredient_map` (
-  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `product_id` int(11) unsigned NOT NULL,
-  `ingredient_id` int(11) NOT NULL,
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `product_id` int unsigned NOT NULL,
+  `ingredient_id` int NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/src/Parse/CreateTable.php
+++ b/src/Parse/CreateTable.php
@@ -476,6 +476,18 @@ class CreateTable
                 $thisDefinition = $this->columns[$columnName]->toString($this->getCollation());
                 $thatDefinition = $that->columns[$columnName]->toString($that->getCollation());
                 
+                // Display width specification for integer data types was deprecated after 8.0.19
+                $patterns = [
+                    '/tinyint\(\d+\)/',
+                    '/smallint\(\d+\)/',
+                    '/mediumint\(\d+\)/',
+                    '/int\(\d+\)/',
+                    '/bigint\(\d+\)/'
+                ];
+                $replacements = ['tinyint', 'smallint', 'mediumint', 'int', 'bigint'];
+                $thisDefinition = preg_replace($patterns, $replacements, $thisDefinition);
+                $thatDefinition = preg_replace($patterns, $replacements, $thatDefinition);
+
                 if (str_contains($thisDefinition, 'utf8mb3')) {
                     $thisDefinition = str_replace('utf8mb3', 'utf8', $thisDefinition);
                 }
@@ -495,7 +507,6 @@ class CreateTable
                     $thisPosition   !== $thatPosition
                 ) {
                     $alter = "MODIFY COLUMN " . $thatDefinition;
-
                     // position has changed
                     if ($thisPosition !== $thatPosition) {
                         $alter .= $thatPosition;

--- a/tests/Parse/ColumnDefinitionTest.php
+++ b/tests/Parse/ColumnDefinitionTest.php
@@ -30,40 +30,36 @@ class ColumnDefinitionTest extends TestCase
     public function parseDatatypesProvider()
     {
         return [
-            ["x int",                       "`x` int(11) DEFAULT NULL"],
-            ["x int signed",                "`x` int(11) DEFAULT NULL"],
-            ["x int unsigned",              "`x` int(10) unsigned DEFAULT NULL"],
-            ["x int(5)",                    "`x` int(5) DEFAULT NULL"],
-            ["x int(5) default null",       "`x` int(5) DEFAULT NULL"],
-            ["x int not null default 1",    "`x` int(11) NOT NULL DEFAULT '1'"],
-            ["x int zerofill",              "`x` int(10) unsigned zerofill DEFAULT NULL"],
-            ["x int zerofill unsigned",     "`x` int(10) unsigned zerofill DEFAULT NULL"],
-            ["x int unsigned zerofill",     "`x` int(10) unsigned zerofill DEFAULT NULL"],
-            ["x int default 1",             "`x` int(11) DEFAULT '1'"],
-            ["x int(4) zerofill default 1", "`x` int(4) unsigned zerofill DEFAULT '0001'"],
-            ["x int auto_increment",        "`x` int(11) NOT NULL AUTO_INCREMENT"],
-            ["x int comment 'blah'",        "`x` int(11) DEFAULT NULL COMMENT 'blah'"],
-            ["x int serial default value",  "`x` int(11) NOT NULL AUTO_INCREMENT"],
+            ["x int",                       "`x` int DEFAULT NULL"],
+            ["x int signed",                "`x` int DEFAULT NULL"],
+            ["x int unsigned",              "`x` int unsigned DEFAULT NULL"],
+            ["x int(5)",                    "`x` int DEFAULT NULL"],
+            ["x int(5) default null",       "`x` int DEFAULT NULL"],
+            ["x int not null default 1",    "`x` int NOT NULL DEFAULT '1'"],
+            ["x int default 1",             "`x` int DEFAULT '1'"],
+            ["x int auto_increment",        "`x` int NOT NULL AUTO_INCREMENT"],
+            ["x int comment 'blah'",        "`x` int DEFAULT NULL COMMENT 'blah'"],
+            ["x int serial default value",  "`x` int NOT NULL AUTO_INCREMENT"],
 
-            ["x int primary key",           "`x` int(11) NOT NULL"],
-            ["x int key",                   "`x` int(11) NOT NULL"],
-            ["x int unique",                "`x` int(11) DEFAULT NULL"],
-            ["x int unique key",            "`x` int(11) DEFAULT NULL"],
+            ["x int primary key",           "`x` int NOT NULL"],
+            ["x int key",                   "`x` int NOT NULL"],
+            ["x int unique",                "`x` int DEFAULT NULL"],
+            ["x int unique key",            "`x` int DEFAULT NULL"],
 
-            ["x bit",                       "`x` bit(1) DEFAULT NULL"],
+            ["x bit",                       "`x` bit DEFAULT NULL"],
             ["x bit(4)",                    "`x` bit(4) DEFAULT NULL"],
             ["x bit(4) default 4",          "`x` bit(4) DEFAULT b'100'"],
             ["x bit(4) default b'0101'",    "`x` bit(4) DEFAULT b'101'"],
             ["x bit(8) default x'e4'",      "`x` bit(8) DEFAULT b'11100100'"],
 
-            ["x tinyint",                   "`x` tinyint(4) DEFAULT NULL"],
-            ["x tinyint unsigned",          "`x` tinyint(3) unsigned DEFAULT NULL"],
-            ["x smallint",                  "`x` smallint(6) DEFAULT NULL"],
-            ["x smallint unsigned",         "`x` smallint(5) unsigned DEFAULT NULL"],
-            ["x mediumint",                 "`x` mediumint(9) DEFAULT NULL"],
-            ["x mediumint unsigned",        "`x` mediumint(8) unsigned DEFAULT NULL"],
-            ["x bigint",                    "`x` bigint(20) DEFAULT NULL"],
-            ["x bigint unsigned",           "`x` bigint(20) unsigned DEFAULT NULL"],
+            ["x tinyint",                   "`x` tinyint DEFAULT NULL"],
+            ["x tinyint unsigned",          "`x` tinyint unsigned DEFAULT NULL"],
+            ["x smallint",                  "`x` smallint DEFAULT NULL"],
+            ["x smallint unsigned",         "`x` smallint unsigned DEFAULT NULL"],
+            ["x mediumint",                 "`x` mediumint DEFAULT NULL"],
+            ["x mediumint unsigned",        "`x` mediumint unsigned DEFAULT NULL"],
+            ["x bigint",                    "`x` bigint DEFAULT NULL"],
+            ["x bigint unsigned",           "`x` bigint unsigned DEFAULT NULL"],
 
             ["x double",                    "`x` double DEFAULT NULL"],
             ["x double unsigned",           "`x` double unsigned DEFAULT NULL"],
@@ -79,7 +75,7 @@ class ColumnDefinitionTest extends TestCase
             ["x decimal(8,3)",              "`x` decimal(8,3) DEFAULT NULL"],
             ["x decimal default 1",         "`x` decimal(10,0) DEFAULT '1'"],
             ["x decimal(5,3) default 1",    "`x` decimal(5,3) DEFAULT '1.000'"],
-            ["x decimal(7,3) zerofill default 1",   "`x` decimal(7,3) unsigned zerofill DEFAULT '001.000'"],
+            ["x decimal(7,3) unsigned default 1",    "`x` decimal(7,3) unsigned DEFAULT '1.000'"],
 
             ["x date",                      "`x` date DEFAULT NULL"],
             ["x date default 0",            "`x` date DEFAULT '0000-00-00'"],
@@ -182,7 +178,7 @@ class ColumnDefinitionTest extends TestCase
             ["x set('a', 'b', 'c') NOT NULL",      "`x` set('a','b','c') NOT NULL"],
             ["x set('a', 'b', 'c') default ''",      "`x` set('a','b','c') DEFAULT ''"],
 
-            ["x serial",                 "`x` bigint(20) unsigned NOT NULL AUTO_INCREMENT"],
+            ["x serial",                 "`x` bigint unsigned NOT NULL AUTO_INCREMENT"],
 
             ["x character",              "`x` char(1) DEFAULT NULL"],
             ["x character(10)",          "`x` char(10) DEFAULT NULL"],
@@ -196,38 +192,38 @@ class ColumnDefinitionTest extends TestCase
             ["x long varchar",        "`x` mediumtext"],
             ["x long",                "`x` mediumtext"],
 
-            ["x bool",                "`x` tinyint(1) DEFAULT NULL"],
-            ["x boolean",             "`x` tinyint(1) DEFAULT NULL"],
-            ["x bool NOT NULL",       "`x` tinyint(1) NOT NULL"],
-            ["x boolean NOT NULL",    "`x` tinyint(1) NOT NULL"],
+            ["x bool",                "`x` tinyint DEFAULT NULL"],
+            ["x boolean",             "`x` tinyint DEFAULT NULL"],
+            ["x bool NOT NULL",       "`x` tinyint NOT NULL"],
+            ["x boolean NOT NULL",    "`x` tinyint NOT NULL"],
 
-            ["x int1",                "`x` tinyint(4) DEFAULT NULL"],
-            ["x int1(3)",             "`x` tinyint(3) DEFAULT NULL"],
-            ["x int1 NOT NULL",       "`x` tinyint(4) NOT NULL"],
+            ["x int1",                "`x` tinyint DEFAULT NULL"],
+            ["x int1(3)",             "`x` tinyint DEFAULT NULL"],
+            ["x int1 NOT NULL",       "`x` tinyint NOT NULL"],
 
-            ["x int2",                "`x` smallint(6) DEFAULT NULL"],
-            ["x int2(3)",             "`x` smallint(3) DEFAULT NULL"],
-            ["x int2 NOT NULL",       "`x` smallint(6) NOT NULL"],
+            ["x int2",                "`x` smallint DEFAULT NULL"],
+            ["x int2(3)",             "`x` smallint DEFAULT NULL"],
+            ["x int2 NOT NULL",       "`x` smallint NOT NULL"],
 
-            ["x int3",                "`x` mediumint(9) DEFAULT NULL"],
-            ["x int3(3)",             "`x` mediumint(3) DEFAULT NULL"],
-            ["x int3 NOT NULL",       "`x` mediumint(9) NOT NULL"],
+            ["x int3",                "`x` mediumint DEFAULT NULL"],
+            ["x int3(3)",             "`x` mediumint DEFAULT NULL"],
+            ["x int3 NOT NULL",       "`x` mediumint NOT NULL"],
 
-            ["x middleint",           "`x` mediumint(9) DEFAULT NULL"],
-            ["x middleint(3)",        "`x` mediumint(3) DEFAULT NULL"],
-            ["x middleint NOT NULL",  "`x` mediumint(9) NOT NULL"],
+            ["x middleint",           "`x` mediumint DEFAULT NULL"],
+            ["x middleint(3)",        "`x` mediumint DEFAULT NULL"],
+            ["x middleint NOT NULL",  "`x` mediumint NOT NULL"],
 
-            ["x int4",                "`x` int(11) DEFAULT NULL"],
-            ["x int4(3)",             "`x` int(3) DEFAULT NULL"],
-            ["x int4 NOT NULL",       "`x` int(11) NOT NULL"],
+            ["x int4",                "`x` int DEFAULT NULL"],
+            ["x int4(3)",             "`x` int DEFAULT NULL"],
+            ["x int4 NOT NULL",       "`x` int NOT NULL"],
 
-            ["x integer",             "`x` int(11) DEFAULT NULL"],
-            ["x integer(3)",          "`x` int(3) DEFAULT NULL"],
-            ["x integer NOT NULL",    "`x` int(11) NOT NULL"],
+            ["x integer",             "`x` int DEFAULT NULL"],
+            ["x integer(3)",          "`x` int DEFAULT NULL"],
+            ["x integer NOT NULL",    "`x` int NOT NULL"],
 
-            ["x int8",                "`x` bigint(20) DEFAULT NULL"],
-            ["x int8(3)",             "`x` bigint(3) DEFAULT NULL"],
-            ["x int8 NOT NULL",       "`x` bigint(20) NOT NULL"],
+            ["x int8",                "`x` bigint DEFAULT NULL"],
+            ["x int8(3)",             "`x` bigint DEFAULT NULL"],
+            ["x int8 NOT NULL",       "`x` bigint NOT NULL"],
 
             ["x dec",                 "`x` decimal(10,0) DEFAULT NULL"],
             ["x dec(8)",              "`x` decimal(8,0) DEFAULT NULL"],
@@ -252,7 +248,7 @@ class ColumnDefinitionTest extends TestCase
             ["x json NOT NULL",       "`x` json NOT NULL"],
 
             // Ignore unrecognised column options
-            ["x int foo",             "`x` int(11) DEFAULT NULL"],
+            ["x int foo",             "`x` int DEFAULT NULL"],
         ];
     }
 
@@ -280,6 +276,8 @@ class ColumnDefinitionTest extends TestCase
             ["x null"],
             // No identifier
             ["int"],
+            // Unexpected ZEROFILL keyword
+            ["x int zerofill"],
             // No comma separator
             ["x set('a'|'b')"],
             // Unexpected parentheses
@@ -408,10 +406,8 @@ class ColumnDefinitionTest extends TestCase
             // [ Column definition, uninitialised value ]
             ["x enum('a', 'b', 'c')",   "a"],
             ["x int",                   "0"],
-            ["x int(5) zerofill",       "00000"],
             ["x decimal",               "0"],
             ["x decimal(5,3)",          "0.000"],
-            ["x decimal(5,1) zerofill", "000.0"],
             ["x char",                  ""],
             ["x blob",                  null],
         ];

--- a/tests/Parse/CreateDatabaseTest.php
+++ b/tests/Parse/CreateDatabaseTest.php
@@ -263,7 +263,7 @@ class CreateDatabaseTest extends TestCase
         /** @var CreateTable|Mockery\MockInterface $tableA */
         $tableA = Mockery::mock(CreateTable::class);
         $tableA->shouldReceive('getName')->andReturn('t');
-        $tableA->shouldReceive('getDDL')->andReturn(["CREATE TABLE `t` (\n  `a` int(11) DEFAULT NULL\n) ENGINE=E"]);
+        $tableA->shouldReceive('getDDL')->andReturn(["CREATE TABLE `t` (\n  `a` int DEFAULT NULL\n) ENGINE=E"]);
 
         $db2 = new CreateDatabase($collationInfo);
         $db2->addTable($tableA);
@@ -272,7 +272,7 @@ class CreateDatabaseTest extends TestCase
             $db1,
             $db2,
             [],
-            ["CREATE TABLE `t` (\n  `a` int(11) DEFAULT NULL\n) ENGINE=E"]
+            ["CREATE TABLE `t` (\n  `a` int DEFAULT NULL\n) ENGINE=E"]
         ];
 
         // Table added
@@ -285,7 +285,7 @@ class CreateDatabaseTest extends TestCase
             $db1,
             $db2,
             [],
-            ["CREATE TABLE `t` (\n  `a` int(11) DEFAULT NULL\n) ENGINE=E"]
+            ["CREATE TABLE `t` (\n  `a` int DEFAULT NULL\n) ENGINE=E"]
         ];
 
         // Table added (but ignored)
@@ -331,12 +331,12 @@ class CreateDatabaseTest extends TestCase
         /** @var CreateTable|Mockery\MockInterface $tableWithEngineBar */
         $tableWithEngineBar = Mockery::mock(CreateTable::class);
         $tableWithEngineBar->shouldReceive('getName')->andReturn('t');
-        $tableWithEngineBar->shouldReceive('getDDL')->andReturn(["CREATE TABLE `t` (\n  `a` int(11) DEFAULT NULL\n) ENGINE=BAR"]);
+        $tableWithEngineBar->shouldReceive('getDDL')->andReturn(["CREATE TABLE `t` (\n  `a` int DEFAULT NULL\n) ENGINE=BAR"]);
 
         /** @var CreateTable|Mockery\MockInterface $tableWithEngineFoo */
         $tableWithEngineFoo = Mockery::mock(CreateTable::class);
         $tableWithEngineFoo->shouldReceive('getName')->andReturn('t');
-        $tableWithEngineFoo->shouldReceive('getDDL')->andReturn(["CREATE TABLE `t` (\n  `a` int(11) DEFAULT NULL\n) ENGINE=FOO"]);
+        $tableWithEngineFoo->shouldReceive('getDDL')->andReturn(["CREATE TABLE `t` (\n  `a` int DEFAULT NULL\n) ENGINE=FOO"]);
         $tableWithEngineFoo
             ->shouldReceive('diff')
             ->with(

--- a/tests/Parse/sql/default.sql
+++ b/tests/Parse/sql/default.sql
@@ -6,7 +6,7 @@ create table t (
 );
 CREATE TABLE `t` (
     `x` text,
-    `y` int(11) DEFAULT NULL
+    `y` int DEFAULT NULL
 ) ENGINE=InnoDB;
 
 -- test ----------------------------------------
@@ -17,8 +17,8 @@ create table t (
     d int not null default 0
 );
 CREATE TABLE `t` (
-    `a` int(11) DEFAULT NULL,
-    `b` int(11) DEFAULT NULL,
-    `c` int(11) NOT NULL,
-    `d` int(11) NOT NULL DEFAULT '0'
+    `a` int DEFAULT NULL,
+    `b` int DEFAULT NULL,
+    `c` int NOT NULL,
+    `d` int NOT NULL DEFAULT '0'
 ) ENGINE=InnoDB;

--- a/tests/Parse/sql/diff/columns.sql
+++ b/tests/Parse/sql/diff/columns.sql
@@ -7,7 +7,7 @@ create table t (
     b int
 );
 ALTER TABLE `t`
-ADD COLUMN `b` int(11) DEFAULT NULL
+ADD COLUMN `b` int DEFAULT NULL
 
 -- test - Add a column at the beginning
 create table t (
@@ -18,7 +18,7 @@ create table t (
     a int
 );
 ALTER TABLE `t`
-ADD COLUMN `b` int(11) DEFAULT NULL FIRST
+ADD COLUMN `b` int DEFAULT NULL FIRST
 
 -- test - Add a column at somewhere in the middle
 create table t (
@@ -31,7 +31,7 @@ create table t (
     b int
 );
 ALTER TABLE `t`
-ADD COLUMN `c` int(11) DEFAULT NULL AFTER `a`
+ADD COLUMN `c` int DEFAULT NULL AFTER `a`
 
 -- test - Remove a column
 create table t (
@@ -54,13 +54,13 @@ MODIFY COLUMN `a` char(10) DEFAULT NULL
 create table t (a int);
 create table t (a int not null);
 ALTER TABLE `t`
-MODIFY COLUMN `a` int(11) NOT NULL
+MODIFY COLUMN `a` int NOT NULL
 
 -- test - Make a column nullable
 create table t (a int not null);
 create table t (a int);
 ALTER TABLE `t`
-MODIFY COLUMN `a` int(11) DEFAULT NULL
+MODIFY COLUMN `a` int DEFAULT NULL
 
 -- test - Redordering columns: Move a column to the start
 create table t (
@@ -74,7 +74,7 @@ create table t (
     b int
 );
 ALTER TABLE `t`
-MODIFY COLUMN `c` int(11) DEFAULT NULL FIRST
+MODIFY COLUMN `c` int DEFAULT NULL FIRST
 
 -- test - Redordering columns: Move a column to the end
 create table t (
@@ -88,8 +88,8 @@ create table t (
     a int
 );
 ALTER TABLE `t`
-MODIFY COLUMN `b` int(11) DEFAULT NULL FIRST,
-MODIFY COLUMN `c` int(11) DEFAULT NULL AFTER `b`
+MODIFY COLUMN `b` int DEFAULT NULL FIRST,
+MODIFY COLUMN `c` int DEFAULT NULL AFTER `b`
 
 -- test - Redordering columns: Move a column in the middle
 create table t (
@@ -103,5 +103,5 @@ create table t (
     b int
 );
 ALTER TABLE `t`
-MODIFY COLUMN `c` int(11) DEFAULT NULL AFTER `a`
+MODIFY COLUMN `c` int DEFAULT NULL AFTER `a`
 

--- a/tests/Parse/sql/diff/foreignKeys.sql
+++ b/tests/Parse/sql/diff/foreignKeys.sql
@@ -1,9 +1,9 @@
 -- test - Add unnamed foreign key
 create table t (
-    `ux` int(11) DEFAULT NULL
+    `ux` int DEFAULT NULL
 );
 create table t (
-    `ux` int(11) DEFAULT NULL,
+    `ux` int DEFAULT NULL,
     FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
 );
 ALTER TABLE `t`
@@ -12,10 +12,10 @@ ADD CONSTRAINT `t_ibfk_1` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
 
 -- test - Add named foreign key
 create table t (
-    `ux` int(11) DEFAULT NULL
+    `ux` int DEFAULT NULL
 );
 create table t (
-    `ux` int(11) DEFAULT NULL,
+    `ux` int DEFAULT NULL,
     CONSTRAINT `forKey1` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
 );
 ALTER TABLE `t`
@@ -24,11 +24,11 @@ ADD CONSTRAINT `forKey1` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
 
 -- test - Key automatically gets added for foreign key as per MySQL
 create table t (
-    `ux` int(11) DEFAULT NULL,
+    `ux` int DEFAULT NULL,
     CONSTRAINT `forKey1` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
 );
 create table t (
-    `ux` int(11) DEFAULT NULL,
+    `ux` int DEFAULT NULL,
     CONSTRAINT `forKey1` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
 );
 ALTER TABLE `t`
@@ -36,44 +36,44 @@ ADD KEY `forKey1` (`ux`)
 
 -- test - Automatically added key already exists in the current table so no change is required
 create table t (
-    `ux` int(11) DEFAULT NULL,
+    `ux` int DEFAULT NULL,
     KEY `forKey1` (`ux`),
     CONSTRAINT `forKey1` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
 );
 create table t (
-    `ux` int(11) DEFAULT NULL,
+    `ux` int DEFAULT NULL,
     CONSTRAINT `forKey1` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
 );
 
 -- test - Drop unnamed foreign key
 create table t (
-    `ux` int(11) DEFAULT NULL,
+    `ux` int DEFAULT NULL,
     FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
 );
 create table t (
-    `ux` int(11) DEFAULT NULL
+    `ux` int DEFAULT NULL
 );
 ALTER TABLE `t`
 DROP FOREIGN KEY `t_ibfk_1`
 
 -- test - Drop named foreign key
 create table t (
-    `ux` int(11) DEFAULT NULL,
+    `ux` int DEFAULT NULL,
     CONSTRAINT `forKey1` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
 );
 create table t (
-    `ux` int(11) DEFAULT NULL
+    `ux` int DEFAULT NULL
 );
 ALTER TABLE `t`
 DROP FOREIGN KEY `forKey1`
 
 -- test - Rename foreign key
 create table t (
-    `ux` int(11) DEFAULT NULL,
+    `ux` int DEFAULT NULL,
     CONSTRAINT `foo` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
 );
 create table t (
-    `ux` int(11) DEFAULT NULL,
+    `ux` int DEFAULT NULL,
     CONSTRAINT `bar` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
 );
 ALTER TABLE `t`

--- a/tests/Parse/sql/diff/indexes.sql
+++ b/tests/Parse/sql/diff/indexes.sql
@@ -2,14 +2,14 @@
 create table t (a int);
 create table t (a int primary key);
 ALTER TABLE `t`
-MODIFY COLUMN `a` int(11) NOT NULL,
+MODIFY COLUMN `a` int NOT NULL,
 ADD PRIMARY KEY (`a`)
 
 -- test - Remove primary key
 create table t (a int primary key);
 create table t (a int);
 ALTER TABLE `t`
-MODIFY COLUMN `a` int(11) DEFAULT NULL,
+MODIFY COLUMN `a` int DEFAULT NULL,
 DROP PRIMARY KEY
 
 -- test - Add a named index

--- a/tests/Parse/sql/foreignKey.sql
+++ b/tests/Parse/sql/foreignKey.sql
@@ -4,7 +4,7 @@ create table t (
     foreign key (ux) references u (x)
 );
 CREATE TABLE `t` (
-    `ux` int(11) DEFAULT NULL,
+    `ux` int DEFAULT NULL,
     KEY `ux` (`ux`),
     CONSTRAINT `t_ibfk_1` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
 ) ENGINE=InnoDB;
@@ -15,7 +15,7 @@ create table t (
     foreign key fk_t_u_x (ux) references u (x)
 );
 CREATE TABLE `t` (
-    `ux` int(11) DEFAULT NULL,
+    `ux` int DEFAULT NULL,
     KEY `fk_t_u_x` (`ux`),
     CONSTRAINT `t_ibfk_1` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
 ) ENGINE=InnoDB;
@@ -26,8 +26,8 @@ create table t (
     vx int, foreign key (vx) references v (x)
 );
 CREATE TABLE `t` (
-    `ux` int(11) DEFAULT NULL,
-    `vx` int(11) DEFAULT NULL,
+    `ux` int DEFAULT NULL,
+    `vx` int DEFAULT NULL,
     KEY `ux` (`ux`),
     KEY `vx` (`vx`),
     CONSTRAINT `t_ibfk_1` FOREIGN KEY (`ux`) REFERENCES `u` (`x`),
@@ -40,7 +40,7 @@ create table t (
     constraint c1 foreign key (ux) references u (x)
 );
 CREATE TABLE `t` (
-    `ux` int(11) DEFAULT NULL,
+    `ux` int DEFAULT NULL,
     KEY `c1` (`ux`),
     CONSTRAINT `c1` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
 ) ENGINE=InnoDB;
@@ -52,7 +52,7 @@ create table t (
     foreign key (ux) references u (x)
 );
 CREATE TABLE `t` (
-    `ux` int(11) DEFAULT NULL,
+    `ux` int DEFAULT NULL,
     KEY `k1` (`ux`),
     CONSTRAINT `t_ibfk_1` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
 ) ENGINE=InnoDB;
@@ -65,8 +65,8 @@ create table t (
     foreign key (ux) references u (x)
 );
 CREATE TABLE `t` (
-    `ux` int(11) DEFAULT NULL,
-    `ty` int(11) DEFAULT NULL,
+    `ux` int DEFAULT NULL,
+    `ty` int DEFAULT NULL,
     KEY `k1` (`ux`,`ty`),
     CONSTRAINT `t_ibfk_1` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
 ) ENGINE=InnoDB;
@@ -79,8 +79,8 @@ create table t (
     foreign key (ux) references u (x)
 );
 CREATE TABLE `t` (
-    `ux` int(11) DEFAULT NULL,
-    `ty` int(11) DEFAULT NULL,
+    `ux` int DEFAULT NULL,
+    `ty` int DEFAULT NULL,
     KEY `k1` (`ty`,`ux`),
     KEY `ux` (`ux`),
     CONSTRAINT `t_ibfk_1` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
@@ -94,8 +94,8 @@ create table t (
     foreign key (ux) references u (x)
 );
 CREATE TABLE `t` (
-    `ux` int(11) DEFAULT NULL,
-    `ty` int(11) DEFAULT NULL,
+    `ux` int DEFAULT NULL,
+    `ty` int DEFAULT NULL,
     KEY `k1` (`ty`),
     KEY `ux` (`ux`),
     CONSTRAINT `t_ibfk_1` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)
@@ -109,8 +109,8 @@ create table t (
     key k1 (ty)
 );
 CREATE TABLE `t` (
-    `ux` int(11) DEFAULT NULL,
-    `ty` int(11) DEFAULT NULL,
+    `ux` int DEFAULT NULL,
+    `ty` int DEFAULT NULL,
     KEY `ux` (`ux`),
     KEY `k1` (`ty`),
     CONSTRAINT `t_ibfk_1` FOREIGN KEY (`ux`) REFERENCES `u` (`x`)

--- a/tests/Parse/sql/nonUniqueIndex.sql
+++ b/tests/Parse/sql/nonUniqueIndex.sql
@@ -5,7 +5,7 @@ create table t (
     index (x)
 );
 CREATE TABLE `t` ( 
-    `x` int(11) DEFAULT NULL,
+    `x` int DEFAULT NULL,
     KEY `x` (`x`) 
 ) ENGINE=InnoDB;
 
@@ -15,7 +15,7 @@ create table t (
     key (x) 
 );
 CREATE TABLE `t` (
-    `x` int(11) DEFAULT NULL,
+    `x` int DEFAULT NULL,
     KEY `x` (`x`) 
 ) ENGINE=InnoDB;
 
@@ -27,8 +27,8 @@ create table t (
     key (x,y)
 );
 CREATE TABLE `t` (
-    `x` int(11) DEFAULT NULL,
-    `y` int(11) DEFAULT NULL,
+    `x` int DEFAULT NULL,
+    `y` int DEFAULT NULL,
     KEY `x` (`x`),
     KEY `x_2` (`x`,`y`) 
 ) ENGINE=InnoDB;
@@ -41,8 +41,8 @@ create table t (
     key (x,y)
 );
 CREATE TABLE `t` (
-    `x` int(11) NOT NULL DEFAULT '0',
-    `y` int(11) DEFAULT NULL,
+    `x` int NOT NULL DEFAULT '0',
+    `y` int DEFAULT NULL,
     PRIMARY KEY (`x`),
     KEY `x` (`x`,`y`) 
 ) ENGINE=InnoDB;

--- a/tests/Parse/sql/primaryKey.sql
+++ b/tests/Parse/sql/primaryKey.sql
@@ -5,7 +5,7 @@ create table t (
     x text
 );
 CREATE TABLE `t` (
-    `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+    `id` int unsigned NOT NULL AUTO_INCREMENT,
     `x` text,
     PRIMARY KEY (`id`)
 ) ENGINE=InnoDB;
@@ -15,7 +15,7 @@ create table t (
     x int primary key
 ); 
 CREATE TABLE `t` (
-    `x` int(11) NOT NULL,
+    `x` int NOT NULL,
     PRIMARY KEY (`x`)
 ) ENGINE=InnoDB;
 
@@ -24,7 +24,7 @@ create table t (
     x int not null primary key
 );
 CREATE TABLE `t` (
-    `x` int(11) NOT NULL,
+    `x` int NOT NULL,
     PRIMARY KEY (`x`)
 ) ENGINE=InnoDB;
 
@@ -34,7 +34,7 @@ create table t (
     primary key (x)
 );
 CREATE TABLE `t` (
-    `x` int(11) NOT NULL DEFAULT '0',
+    `x` int NOT NULL DEFAULT '0',
     PRIMARY KEY (`x`)
 ) ENGINE=InnoDB;
 
@@ -44,18 +44,8 @@ create table t (
     primary key(x)
 );
 CREATE TABLE `t` (
-    `x` int(11) NOT NULL,
+    `x` int NOT NULL,
     PRIMARY KEY (`x`)
-) ENGINE=InnoDB;
-
--- test ----------------------------------------
-create table t (
-    x int(4) zerofill,
-    primary key (x)
-);
-CREATE TABLE `t` (
-    `x` int(4) unsigned zerofill NOT NULL DEFAULT '0000',
-    PRIMARY KEY (`x`) 
 ) ENGINE=InnoDB;
 
 -- test ----------------------------------------
@@ -65,8 +55,8 @@ create table t (
     primary key (x,y) 
 );
 CREATE TABLE `t` (
-    `x` int(11) NOT NULL DEFAULT '0',
-    `y` int(11) NOT NULL DEFAULT '0',
+    `x` int NOT NULL DEFAULT '0',
+    `y` int NOT NULL DEFAULT '0',
     PRIMARY KEY (`x`,`y`)
 ) ENGINE=InnoDB;
 
@@ -76,7 +66,7 @@ create table t (
     constraint primary key (x)
 );
 CREATE TABLE `t` (
-    `x` int(11) NOT NULL DEFAULT '0',
+    `x` int NOT NULL DEFAULT '0',
     PRIMARY KEY (`x`) 
 ) ENGINE=InnoDB;
 
@@ -86,7 +76,7 @@ create table t (
     constraint con primary key (x)
 );
 CREATE TABLE `t` (
-    `x` int(11) NOT NULL DEFAULT '0',
+    `x` int NOT NULL DEFAULT '0',
     PRIMARY KEY (`x`)
 ) ENGINE=InnoDB;
 

--- a/tests/Parse/sql/simpleCreateTable.sql
+++ b/tests/Parse/sql/simpleCreateTable.sql
@@ -38,7 +38,7 @@ exception RuntimeException "Expected a datatype"
 -- test ----------------------------------------
 create table x (int int);
 CREATE TABLE `x` (
-    `int` int(11) DEFAULT NULL
+    `int` int DEFAULT NULL
 ) ENGINE=InnoDB;
 
 -- test ----------------------------------------
@@ -52,7 +52,7 @@ exception RuntimeException "Expected identifier"
 -- test ----------------------------------------
 create table `table` (a int);
 CREATE TABLE `table` (
-    `a` int(11) DEFAULT NULL
+    `a` int DEFAULT NULL
 ) ENGINE=InnoDB;
 
 -- test - Multiple auto increment columns

--- a/tests/Parse/sql/uniqueIndex.sql
+++ b/tests/Parse/sql/uniqueIndex.sql
@@ -5,7 +5,7 @@ create table t (
     unique (x)
 );
 CREATE TABLE `t` (
-    `x` int(11) DEFAULT NULL,
+    `x` int DEFAULT NULL,
     UNIQUE KEY `x` (`x`) 
 ) ENGINE=InnoDB;
 
@@ -15,7 +15,7 @@ create table t (
     constraint unique (x)
 );
 CREATE TABLE `t` (
-    `x` int(11) DEFAULT NULL,
+    `x` int DEFAULT NULL,
     UNIQUE KEY `x` (`x`) 
 ) ENGINE=InnoDB;
 
@@ -25,7 +25,7 @@ create table t (
     unique key (x)
 );
 CREATE TABLE `t` (
-    `x` int(11) DEFAULT NULL,
+    `x` int DEFAULT NULL,
     UNIQUE KEY `x` (`x`) 
 ) ENGINE=InnoDB;
 
@@ -35,7 +35,7 @@ create table t (
     unique index (x)
 );
 CREATE TABLE `t` (
-    `x` int(11) DEFAULT NULL,
+    `x` int DEFAULT NULL,
     UNIQUE KEY `x` (`x`)
 ) ENGINE=InnoDB;
 
@@ -45,6 +45,6 @@ create table t (
     constraint con unique key (x)
 );
 CREATE TABLE `t` (
-    `x` int(11) DEFAULT NULL,
+    `x` int DEFAULT NULL,
     UNIQUE KEY `con` (`x`)
 ) ENGINE=InnoDB;


### PR DESCRIPTION
Remove int width and zerofill for > MySQL 8.0.19

https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-19.html
> Display width specification for integer data types was deprecated in MySQL 8.0.17, and now statements that include data type definitions in their output no longer show the display width for integer types, with these exceptions:
> - The type is TINYINT(1). MySQL Connectors make the assumption that TINYINT(1) columns originated as BOOLEAN columns; this exception enables them to continue to make that assumption.
> - The type includes the ZEROFILL attribute.