### PR TITLE
Skip ROW_FORMAT=FIXED for InnoDB to avoid MySQL 8 error 1031

### DIFF
--- a/src/Extractor.php
+++ b/src/Extractor.php
@@ -443,7 +443,13 @@ class Extractor
         $defTableOptions = [];
         $defTableOptions[] = "ENGINE=$table->ENGINE";
         if (strcasecmp($table->ROW_FORMAT, 'COMPACT') != 0) {
-            $defTableOptions[] = "ROW_FORMAT=$table->ROW_FORMAT";
+            // ROW_FORMAT=FIXED is only valid for MyISAM; MySQL 8 errors with
+            // 1031 if applied to InnoDB. Drop it silently for InnoDB.
+            $skipRowFormat = strcasecmp((string) $table->ROW_FORMAT, 'FIXED') === 0
+                && strcasecmp((string) $table->ENGINE, 'InnoDB') === 0;
+            if (!$skipRowFormat) {
+                $defTableOptions[] = "ROW_FORMAT=$table->ROW_FORMAT";
+            }
         }
         if ($table->AUTO_INCREMENT) {
             $defTableOptions[] = "AUTO_INCREMENT=$table->AUTO_INCREMENT";

--- a/src/Parse/TableOptions.php
+++ b/src/Parse/TableOptions.php
@@ -300,6 +300,14 @@ class TableOptions
         ] as $option) {
             if ($this->options[$option] !== $this->defaultOptions[$option]) {
                 $value = $this->options[$option];
+                // ROW_FORMAT=FIXED is only valid for MyISAM; MySQL 8 errors with
+                // 1031 if applied to InnoDB. Drop it silently for InnoDB.
+                if ($option === 'ROW_FORMAT'
+                    && strcasecmp((string) $value, 'FIXED') === 0
+                    && strcasecmp((string) $this->engine, 'InnoDB') === 0
+                ) {
+                    continue;
+                }
                 if (in_array($option, ['COMMENT', 'CONNECTION'])) {
                     $value = Token::escapeString($value);
                 }

--- a/tests/Parse/TableOptionsTest.php
+++ b/tests/Parse/TableOptionsTest.php
@@ -89,7 +89,10 @@ class TableOptionsTest extends TestCase
 
             ["row_format=default",          "ENGINE=InnoDB"],
             ["row_format=dynamic",          "ENGINE=InnoDB ROW_FORMAT=DYNAMIC"],
-            ["row_format=fixed",            "ENGINE=InnoDB ROW_FORMAT=FIXED"],
+            // ROW_FORMAT=FIXED is invalid for InnoDB on MySQL 8 (error 1031);
+            // morphism silently drops it so the table can be created.
+            ["row_format=fixed",            "ENGINE=InnoDB"],
+            ["engine=MyISAM row_format=fixed", "ENGINE=MyISAM ROW_FORMAT=FIXED"],
             ["row_format=compressed",       "ENGINE=InnoDB ROW_FORMAT=COMPRESSED"],
             ["row_format=redundant",        "ENGINE=InnoDB ROW_FORMAT=REDUNDANT"],
             ["row_format=compact",          "ENGINE=InnoDB ROW_FORMAT=COMPACT"],


### PR DESCRIPTION
## Summary
- `ROW_FORMAT=FIXED` is only valid for MyISAM. MySQL 5.6 silently downgraded it to `COMPACT` for InnoDB; MySQL 8 rejects it with `ERROR 1031: Table storage engine for '<table>' doesn't have this option`, breaking `morphism diff --apply-changes=yes` on schemas that legacy databases were created with.
- This is the same flavour of MySQL 8 compatibility cleanup as #67 (int display width / zerofill).

## Change
- `src/Parse/TableOptions.php` — `toString()` skips emitting `ROW_FORMAT=FIXED` when the engine is InnoDB.
- `src/Extractor.php` — `getTableOptionDefs()` skips `ROW_FORMAT` when INFORMATION_SCHEMA reports `FIXED` on an InnoDB table.
- Both sites only suppress the `FIXED` + `InnoDB` combination. MyISAM still preserves `ROW_FORMAT=FIXED`, and other formats (`DYNAMIC`, `COMPRESSED`, `REDUNDANT`, `COMPACT`) are unchanged.

## Test plan
- [x] `make test-unit` (via `graze/php-alpine:7.4-test`): 727/727 pass.
- [x] Updated `tests/Parse/TableOptionsTest.php`:
  - `row_format=fixed` on default (InnoDB) engine now expects `ENGINE=InnoDB` (no ROW_FORMAT).
  - New case: `engine=MyISAM row_format=fixed` still expects `ENGINE=MyISAM ROW_FORMAT=FIXED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)