### PR TITLE
Publish multi-arch Docker image via buildx

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,6 @@ name: Publish Docker image
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+'
 
 permissions:
@@ -15,6 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Compute build date
+        id: build_date
+        run: echo "value=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -47,6 +50,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            BUILD_DATE=${{ github.event.repository.updated_at }}
+            BUILD_DATE=${{ steps.build_date.outputs.value }}
             VCS_REF=${{ github.sha }}
           provenance: false

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,52 @@
+name: Publish Docker image
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Build & push multi-arch image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: graze/morphism
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_DATE=${{ github.event.repository.updated_at }}
+            VCS_REF=${{ github.sha }}
+          provenance: false

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DOCKER_RUN := ${DOCKER_RUN_BASE} ${IMAGE}
 
 PREFER_LOWEST ?=
 
-.PHONY: build build-update composer-% clean help run
+.PHONY: build build-update build-docker build-docker-multiarch composer-% clean help run
 .PHONY: lint lint-fix
 .PHONY: test test-unit test-integration test-lowest test-matrix test-coverage test-coverage-html test-coverage-clover
 
@@ -37,6 +37,22 @@ composer-%: ## Run a composer command, `make "composer-<command> [...]"`.
 
 ensure-conf-file: # Ensure that there is a configuration file in dev
 	@test -f morphism.conf || cp example/morphism.conf.example morphism.conf
+
+PLATFORMS ?= linux/amd64,linux/arm64
+
+build-docker: ## Build the docker image for the host architecture and load it locally.
+	docker buildx build --load \
+        --build-arg BUILD_DATE="$$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+        --build-arg VCS_REF="$$(git rev-parse --short HEAD)" \
+        -t graze/morphism .
+
+build-docker-multiarch: ## Build the docker image for multiple architectures (no load; set PUSH=1 to push).
+	docker buildx build \
+        --platform ${PLATFORMS} \
+        $(if $(PUSH),--push,) \
+        --build-arg BUILD_DATE="$$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+        --build-arg VCS_REF="$$(git rev-parse --short HEAD)" \
+        -t graze/morphism .
 
 # Testing
 

--- a/hooks/build
+++ b/hooks/build
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set +xe
-
-docker build --build-arg BUILD_DATE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
-    --build-arg VCS_REF="$(git rev-parse --short HEAD)" \
-    -t "$IMAGE_NAME" .


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/docker.yml` to build `linux/amd64` + `linux/arm64` and push `graze/morphism` to Docker Hub on `v*` tag pushes (fixes `no matching manifest for linux/arm64/v8` on Apple Silicon).
- Switches `Makefile` to `docker buildx`: `build-docker` (host-arch, `--load`) and `build-docker-multiarch` (`PLATFORMS`, `PUSH=1` opt-in).
- Removes the legacy Docker Hub Automated Builds `hooks/build`.

Mirrors the pattern landed in graze/sprout#21. Docker tags are emitted via `type=semver` so the `v6.0.5` git tag becomes `6.0.5` / `6.0` / `latest` on Docker Hub.

## Notes
- Requires `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` repo secrets.
- `Dockerfile` runtime base is `graze/php-alpine:7.4` — confirm an `arm64` manifest exists before cutting a tag, otherwise the cross build will fail.

## Test plan
- [ ] Verify `make build-docker` builds locally on host arch.
- [ ] Verify `make build-docker-multiarch` (without `PUSH=1`) cross-builds locally.
- [ ] Confirm `graze/php-alpine:7.4` ships an `arm64` manifest (`docker buildx imagetools inspect graze/php-alpine:7.4`).
- [ ] Cut a test tag (or use workflow_dispatch trial) and verify both arch manifests land on Docker Hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)