### PR TITLE
Bump test database to mysql:8.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   db:
-    image: mysql:8.0
+    image: mysql:8.4
     volumes:
       - ./example/schema:/docker-entrypoint-initdb.d
     environment:


### PR DESCRIPTION
## Summary
- Bumps the `db` service in `docker-compose.yml` from `mysql:8.0` to `mysql:8.4`.

## Context
MySQL 8.4 makes `caching_sha2_password` the mandatory default auth plugin. This mirrors the MySQL 8.4 work done in docker.

morphism connects exclusively via PDO/mysqlnd, which supports `caching_sha2_password` natively (mysqlnd + openssl). It never shells out to the alpine mysql CLI — `mysqldump` in the functional test runs inside the `db` container itself. So no image swap is required here; the version bump is the whole change.

## Test plan
- [x] Ran the full functional flow locally against `mysql:8.4`: `diff --apply-changes yes`, `diff`, `dump`, `mysqldump`, `lint`, `extract` — all pass (PDO auth against caching_sha2_password succeeds).
- [ ] CI `Functional tests` job goes green (uses this same compose file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)